### PR TITLE
Modified RouteSearch.java and NodeCheck.java to compare entities usin…

### DIFF
--- a/decoder/src/main/java/openlr/decoder/routesearch/RouteSearch.java
+++ b/decoder/src/main/java/openlr/decoder/routesearch/RouteSearch.java
@@ -175,7 +175,7 @@ public class RouteSearch {
 			if (isLast && actualElement.getLine().getID() == destline.getID()) {
 				setRouteFound(actualElement);
 				break;
-			} else if (!isLast && actualElement.getLine().getEndNode().equals(e)) {
+			} else if (!isLast && actualElement.getLine().getEndNode().getID() == e.getID()) {
 				Iterator<? extends Line> iter = actualElement.getLine()
 						.getNextLines();
 				boolean destFound = false;

--- a/map/src/main/java/openlr/map/utils/NodeCheck.java
+++ b/map/src/main/java/openlr/map/utils/NodeCheck.java
@@ -162,8 +162,8 @@ public final class NodeCheck {
 	 *         different directions
 	 */
 	public static boolean isPair(final Line line1, final Line line2) {
-		return (line1.getStartNode().equals(line2.getEndNode()) && line1.getEndNode()
-				.equals(line2.getStartNode()));
+		return (line1.getStartNode().getID() == line2.getEndNode().getID()) && (line1.getEndNode().getID() ==
+				line2.getStartNode().getID());
 	}
 
 }


### PR DESCRIPTION
Let's say calculateRoute() in RouteSearch.java is called to find a route between a start line associated with an LRP "n"  and a destination line associated with LRP "n+1".  One of the first steps before exploring the graph is to record the destination line's start node, because that's how it knows it's reached the target line.  Let's say the start node of the destination line is a Node object "o" with an ID of "y". Now we start exploring edges, and let's further suppose the customer is holding object "o" in some sort of LRU cache and decides to do a little housecleaning, and "o" is removed.  Now calculateRoute finally discovers the predecessor of the destination line because a Line object for that predecessor is created and passed to calculateRoute from the preceding call to getNextLines().  The end node id of that predecessor line is the same as the start node id of the destination line, "y".  But "o" has already been deleted, so a new Node object o' is created with an id of "y" and now we're in trouble: calculateRoute checks for completion with o.equals(o') which fails because we're using Object's equals method, and the route search will fail, even though o and o' both refer to exactly the same network object.

The easy fix is to change the call to equals() to a comparison of the two IDs. Maybe a better way is to override Object.equals() in Node.java and Line.java so that if there are any more of these identity checks they'll work as expected.  The risk is that might cause issues with hashing or something
similar somewhere else. A last alternative is to force the caller to implement equals() or a similar method themselves, which doesn't seem like such a great idea.

