### PR TITLE
build: Update plugins and libraries to newest version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 target/
 bin/
 *.iml
+*.class

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -25,13 +25,20 @@
             <groupId>openlr</groupId>
             <artifactId>map</artifactId>
         </dependency>
+
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>
+
         <dependency>
             <groupId>commons-configuration</groupId>
             <artifactId>commons-configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
         </dependency>
 
         <dependency>

--- a/data/src/test/java/openlr/location/utils/LocationDataIteratorTest.java
+++ b/data/src/test/java/openlr/location/utils/LocationDataIteratorTest.java
@@ -50,8 +50,7 @@ import java.util.Iterator;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
+import static org.testng.Assert.*;
 import static org.testng.Assert.assertFalse;
 
 /**

--- a/data/src/test/java/openlr/location/utils/LocationDataIteratorTest.java
+++ b/data/src/test/java/openlr/location/utils/LocationDataIteratorTest.java
@@ -50,8 +50,9 @@ import java.util.Iterator;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertEquals;
 
 /**
  * Tests the {@link LocationDataIterator}.

--- a/data/src/test/java/openlr/utils/locref/boundary/LocRefBoundaryTest.java
+++ b/data/src/test/java/openlr/utils/locref/boundary/LocRefBoundaryTest.java
@@ -56,7 +56,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static junit.framework.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 /**
  * Tests the bounding box calculation on location references.

--- a/decoder/src/test/java/openlr/decoder/data/OpenLRRatingImplTest.java
+++ b/decoder/src/test/java/openlr/decoder/data/OpenLRRatingImplTest.java
@@ -58,7 +58,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 
-import static junit.framework.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
 /**

--- a/decoder/src/test/java/openlr/decoder/database/LocationDatabaseTest.java
+++ b/decoder/src/test/java/openlr/decoder/database/LocationDatabaseTest.java
@@ -47,9 +47,9 @@ import openlr.rawLocRef.RawLocationReference;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;

--- a/decoder/src/test/java/openlr/decoder/worker/DecoderUtilsTest.java
+++ b/decoder/src/test/java/openlr/decoder/worker/DecoderUtilsTest.java
@@ -10,7 +10,7 @@ import openlr.decoder.properties.OpenLRDecoderProperties;
 import openlr.map.Line;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.junit.Assert;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;

--- a/encoder/src/test/java/openlr/encoder/wpaper/GeoCoordinateLocationTest.java
+++ b/encoder/src/test/java/openlr/encoder/wpaper/GeoCoordinateLocationTest.java
@@ -44,7 +44,7 @@ import openlr.map.GeoCoordinates;
 import openlr.map.InvalidMapDataException;
 import org.testng.annotations.Test;
 
-import static junit.framework.Assert.assertEquals;
+import static org.testng.Assert.*;
 
 /**
  * Tests the encoding examples from the OpenLr White paper.
@@ -99,9 +99,9 @@ public class GeoCoordinateLocationTest extends AbstractEncoderTest {
         GeoCoordinates inputPoi = inputLocation.getPointLocation();
 
         String message = "Encoded GEO-coordinate doesn't match the input data.";
-        assertEquals(message, coords.getLatitudeDeg(), inputPoi
-                .getLatitudeDeg());
-        assertEquals(message, coords.getLongitudeDeg(), inputPoi
-                .getLongitudeDeg());
+        assertEquals(coords.getLatitudeDeg(), inputPoi
+                .getLatitudeDeg(), message);
+        assertEquals(coords.getLongitudeDeg(), inputPoi
+                .getLongitudeDeg(), message);
     }
 }

--- a/encoder/src/test/java/openlr/encoder/wpaper/GeoCoordinateLocationTest.java
+++ b/encoder/src/test/java/openlr/encoder/wpaper/GeoCoordinateLocationTest.java
@@ -44,7 +44,7 @@ import openlr.map.GeoCoordinates;
 import openlr.map.InvalidMapDataException;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
 
 /**
  * Tests the encoding examples from the OpenLr White paper.

--- a/encoder/src/test/java/openlr/encoder/wpaper/POIWithAccessPointLocationTest.java
+++ b/encoder/src/test/java/openlr/encoder/wpaper/POIWithAccessPointLocationTest.java
@@ -44,7 +44,7 @@ import openlr.map.GeoCoordinates;
 import openlr.map.InvalidMapDataException;
 import org.testng.annotations.Test;
 
-import static junit.framework.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 /**
  * Tests the encoding examples from the OpenLr White paper.
@@ -102,9 +102,9 @@ public class POIWithAccessPointLocationTest extends AbstractEncoderTest {
         GeoCoordinates inputPoi = inputLocation.getPointLocation();
 
         String message = "Encoded POI doesn't match the input data.";
-        assertEquals(message, coords.getLatitudeDeg(), inputPoi
-                .getLatitudeDeg());
-        assertEquals(message, coords.getLongitudeDeg(), inputPoi
-                .getLongitudeDeg());
+        assertEquals(coords.getLatitudeDeg(), inputPoi
+                .getLatitudeDeg(), message);
+        assertEquals(coords.getLongitudeDeg(), inputPoi
+                .getLongitudeDeg(), message);
     }
 }

--- a/map/pom.xml
+++ b/map/pom.xml
@@ -38,6 +38,7 @@
             <groupId>commons-configuration</groupId>
             <artifactId>commons-configuration</artifactId>
         </dependency>
+
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>

--- a/map/src/test/java/openlr/map/utils/PathUtilsTest.java
+++ b/map/src/test/java/openlr/map/utils/PathUtilsTest.java
@@ -39,7 +39,7 @@
  */
 package openlr.map.utils;
 
-import junit.framework.Assert;
+import org.testng.Assert;
 import openlr.map.Line;
 import openlr.map.utils.PQElem.PQElemComparator;
 import org.jmock.Expectations;

--- a/maploader-tt-sqlite/src/main/java/openlr/map/sqlite/impl/DBConnection.java
+++ b/maploader-tt-sqlite/src/main/java/openlr/map/sqlite/impl/DBConnection.java
@@ -107,7 +107,7 @@ public class DBConnection {
      * @throws ClassNotFoundException the class not found exception
      * @throws SQLException           the sQL exception
      */
-    public DBConnection(final String db) throws ClassNotFoundException, SQLException {
+    public DBConnection(final String db) throws Exception {
         connection = getDatabaseConnection(db);
         try {
             psGetLine = connection
@@ -233,7 +233,7 @@ public class DBConnection {
      * @throws SQLException           if opening the database connection fails.
      */
     private Connection getDatabaseConnection(final String db)
-            throws ClassNotFoundException, SQLException {
+            throws Exception {
         assert db != null;
         if (LOG.isDebugEnabled()) {
             String mode = "pure-java";

--- a/maploader-tt-sqlite/src/main/java/openlr/map/sqlite/impl/MapDatabaseImpl.java
+++ b/maploader-tt-sqlite/src/main/java/openlr/map/sqlite/impl/MapDatabaseImpl.java
@@ -110,7 +110,7 @@ public final class MapDatabaseImpl implements openlr.map.MapDatabase {
      *
      * @param db a SQLite database which holds the network.
      */
-    public MapDatabaseImpl(final String db) {
+    public MapDatabaseImpl(final String db) throws Exception {
         /* Validate arguments. */
         if (db == null) {
             throw new IllegalArgumentException("Database file not specified.");
@@ -151,7 +151,7 @@ public final class MapDatabaseImpl implements openlr.map.MapDatabase {
      * @throws SQLException If opening the database connection fails
      */
     public MapDatabaseImpl(final InputStream databaseStream)
-            throws IOException, SQLException {
+            throws Exception {
         this(databaseStream, File.createTempFile("openlrMap", ".sqlite"));
     }
 
@@ -176,7 +176,7 @@ public final class MapDatabaseImpl implements openlr.map.MapDatabase {
      * @throws SQLException If opening the database connection fails
      */
     public MapDatabaseImpl(final InputStream databaseStream,
-                           final File tempDataTarget) throws IOException, SQLException {
+                           final File tempDataTarget) throws Exception {
         if (databaseStream == null) {
             throw new IllegalArgumentException(
                     "Database stream must not be null.");

--- a/maploader-tt-sqlite/src/test/java/openlr/map/sqlite/MapDatabaseImplTest.java
+++ b/maploader-tt-sqlite/src/test/java/openlr/map/sqlite/MapDatabaseImplTest.java
@@ -113,6 +113,8 @@ public class MapDatabaseImplTest {
             Assert.fail("Unexpected exception", e);
         } catch (SQLException e) {
             Assert.fail("Unexpected exception", e);
+        } catch (Exception e) {
+            e.printStackTrace();
         }
     }
 
@@ -138,6 +140,8 @@ public class MapDatabaseImplTest {
             Assert.fail("Unexpected exception", e);
         } catch (SQLException e) {
             Assert.fail("Unexpected exception", e);
+        } catch (Exception e) {
+            e.printStackTrace();
         }
     }
 
@@ -160,6 +164,8 @@ public class MapDatabaseImplTest {
             Assert.fail("Unexpected exception", e);
         } catch (SQLException e) {
             Assert.fail("Unexpected exception", e);
+        } catch (Exception e) {
+            e.printStackTrace();
         }
     }
 
@@ -195,7 +201,12 @@ public class MapDatabaseImplTest {
 
     @Test
     public final void testAllLinesAndNodes() {
-        MapDatabase map = new MapDatabaseImpl(PATH_TO_MAP);
+        MapDatabase map = null;
+        try {
+            map = new MapDatabaseImpl(PATH_TO_MAP);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
         Assert.assertEquals(convertToList(map.getAllLines()).size(),
                 EXPECTED_NUMBER_OF_LINES);
         Assert.assertEquals(convertToList(map.getAllNodes()).size(),
@@ -204,7 +215,12 @@ public class MapDatabaseImplTest {
 
     @Test
     public final void testAllBBox() {
-        MapDatabase map = new MapDatabaseImpl(PATH_TO_MAP);
+        MapDatabase map = null;
+        try {
+            map = new MapDatabaseImpl(PATH_TO_MAP);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
         Rectangle2D.Double bbox = map.getMapBoundingBox();
         Assert.assertEquals(bbox.x, 5.0953228);
         Assert.assertEquals(bbox.y, 52.0995754);
@@ -214,7 +230,12 @@ public class MapDatabaseImplTest {
 
     @Test
     public final void testClosestLines() {
-        MapDatabase map = new MapDatabaseImpl(PATH_TO_MAP);
+        MapDatabase map = null;
+        try {
+            map = new MapDatabaseImpl(PATH_TO_MAP);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
         List<Line> lines = convertToList(map.findLinesCloseByCoordinate(
                 5.09500, 52.10000, 200));
         Assert.assertTrue(lines.contains(map.getLine(15280001229410L)));
@@ -231,7 +252,12 @@ public class MapDatabaseImplTest {
 
     @Test
     public final void testClosestNodes() {
-        MapDatabase map = new MapDatabaseImpl(PATH_TO_MAP);
+        MapDatabase map = null;
+        try {
+            map = new MapDatabaseImpl(PATH_TO_MAP);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
         List<Node> nodes = convertToList(map.findNodesCloseByCoordinate(
                 5.09500, 52.10000, 200));
         Assert.assertTrue(nodes.contains(map.getNode(15280200242589L)));

--- a/openlr-parent/pom.xml
+++ b/openlr-parent/pom.xml
@@ -44,13 +44,15 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-report-plugin</artifactId>
-                    <version>3.0.0-M1</version>
+                    <version>3.0.0-M3</version>
                 </plugin>
 
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>2.3.2</version>
+                    <version>3.8.1</version>
                     <configuration>
                         <source>1.7</source>
                         <target>1.7</target>
@@ -58,10 +60,11 @@
                 </plugin>
 
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.8</version>
+                    <version>3.1.1</version>
                     <configuration>
-                        <additionalparam>-Xdoclint:none</additionalparam>
+                        <doclint>none</doclint>
                         <archive>
                             <manifestFile>src/main/resources/templates/MANIFEST.MF</manifestFile>
                         </archive>
@@ -120,7 +123,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-changes-plugin</artifactId>
-                    <version>2.8</version>
+                    <version>2.12.1</version>
                     <configuration>
                         <template>changelog.txt</template>
                         <templateDirectory>src/main/resources/templates</templateDirectory>
@@ -136,8 +139,9 @@
                 </plugin>
 
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>2.1.2</version>
+                    <version>3.1.0</version>
                     <configuration>
                         <attach>true</attach>
                         <archive>
@@ -166,12 +170,12 @@
                 </plugin>
 
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.3.1</version>
+                    <version>3.1.2</version>
                     <executions>
                         <execution>
                             <goals>
-                                <goal>jar</goal>
                                 <goal>test-jar</goal>
                             </goals>
                         </execution>
@@ -192,10 +196,11 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>truezip-maven-plugin</artifactId>
-                    <version>1.0-beta-5</version>
+                    <version>1.2</version>
                 </plugin>
 
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration>
                         <excludedGroups>broken</excludedGroups>
@@ -204,8 +209,9 @@
                 </plugin>
 
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.1.0</version>
                 </plugin>
 
                 <plugin>
@@ -217,7 +223,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.0.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -228,16 +234,17 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
+                <version>3.0.5</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jxr-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.0.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-changes-plugin</artifactId>
-                <version>2.5</version>
+                <version>2.12.1</version>
                 <reportSets>
                     <reportSet>
                         <reports>
@@ -250,7 +257,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.7</version>
+                <version>3.1.0</version>
                 <configuration>
                     <configLocation>${basedir}/checkstyle_openlr.xml</configLocation>
                     <excludes>
@@ -263,7 +270,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8</version>
+                <version>3.1.1</version>
                 <configuration>
                     <doctitle>OpenLR&#8482; API</doctitle>
                     <windowtitle>OpenLR&#8482; API</windowtitle>
@@ -286,7 +293,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.12.0</version>
                 <configuration>
                     <targetJdk>1.6</targetJdk>
                     <excludes>
@@ -300,7 +307,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>javancss-maven-plugin</artifactId>
-                <version>2.0</version>
+                <version>2.1</version>
                 <configuration>
                     <linkXRef>false</linkXRef>
                 </configuration>
@@ -315,13 +322,19 @@
             <dependency>
                 <groupId>commons-configuration</groupId>
                 <artifactId>commons-configuration</artifactId>
-                <version>1.9</version>
+                <version>1.10</version>
+            </dependency>
+
+            <dependency>
+                <groupId>commons-collections</groupId>
+                <artifactId>commons-collections</artifactId>
+                <version>3.2.2</version>
             </dependency>
 
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.7</version>
+                <version>1.13</version>
             </dependency>
 
             <dependency>
@@ -368,13 +381,13 @@
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
-                <version>6.8</version>
+                <version>7.0.0</version>
             </dependency>
 
             <dependency>
                 <groupId>org.jmock</groupId>
                 <artifactId>jmock-legacy</artifactId>
-                <version>2.5.1</version>
+                <version>2.12.0</version>
             </dependency>
 
             <dependency>
@@ -392,25 +405,25 @@
             <dependency>
                 <groupId>de.micromata.jak</groupId>
                 <artifactId>JavaAPIforKml</artifactId>
-                <version>2.2.0</version>
+                <version>2.2.1</version>
             </dependency>
 
             <dependency>
                 <groupId>com.sun.xml.bind</groupId>
                 <artifactId>jaxb-impl</artifactId>
-                <version>2.2</version>
+                <version>2.3.2</version>
             </dependency>
 
             <dependency>
                 <groupId>com.sun.xml.bind</groupId>
                 <artifactId>jaxb-xjc</artifactId>
-                <version>2.2</version>
+                <version>2.3.2</version>
             </dependency>
 
             <dependency>
                 <groupId>org.xerial</groupId>
                 <artifactId>sqlite-jdbc</artifactId>
-                <version>3.7.2</version>
+                <version>3.28.0</version>
             </dependency>
 
         </dependencies>
@@ -433,7 +446,7 @@
 
                         <plugin>
                             <artifactId>maven-source-plugin</artifactId>
-                            <version>2.1.2</version>
+                            <version>3.1.0</version>
                             <configuration>
                                 <attach>true</attach>
                                 <archive>
@@ -495,7 +508,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-report-plugin</artifactId>
-                        <version>2.9</version>
+                        <version>3.0.0-M3</version>
                         <configuration>
                             <excludedGroups>broken</excludedGroups>
                         </configuration>
@@ -504,7 +517,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.9</version>
+                        <version>3.0.0-M3</version>
                         <configuration>
                             <excludedGroups>broken</excludedGroups>
                         </configuration>
@@ -513,7 +526,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>cobertura-maven-plugin</artifactId>
-                        <version>2.5.1</version>
+                        <version>2.7</version>
                         <configuration>
                             <check>
                                 <lineRate>0</lineRate>

--- a/xml/src/test/java/openlr/xml/CircleTest.java
+++ b/xml/src/test/java/openlr/xml/CircleTest.java
@@ -39,7 +39,7 @@
  */
 package openlr.xml;
 
-import junit.framework.Assert;
+import org.testng.Assert;
 import openlr.LocationReference;
 import openlr.LocationType;
 import openlr.PhysicalFormatException;


### PR DESCRIPTION
Update all plugins and libraries except **commons-configuration**. Migration to version 2.0 of the library may require major code change. The updating will be done by the next commit  