### PR TITLE
Prepare POM for pushing artefacts to Maven Central

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,5 @@
 OpenLR(tm)
+
     Copyright 2009-2019 TomTom International B.V.
 
       This product includes software developed at
@@ -21,12 +22,3 @@ OpenLR(tm)
       This project also includes code under copyright of the following institutions:
 
         Copyright (c) 1999 CERN - European Organization for Nuclear Research.
-
-
-
-
-
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# openlr
-----------
+# OpenLR
 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/7d866929be7c43cdae32dac4be3eaa6f)](https://www.codacy.com/app/rijnb/openlr?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=tomtom-international/openlr&amp;utm_campaign=Badge_Grade)
 [![Build Status](https://img.shields.io/travis/tomtom-international/openlr.svg?branch=master)](https://travis-ci.org/tomtom-international/openlr.svg?branch=master)
@@ -8,7 +7,6 @@
 [![Release](https://img.shields.io/github/release/tomtom-international/openlr.svg?maxAge=3600)](https://github.com/tomtom-international/openlr/releases)
 
 ## Installation
-----------------
 
 To build all the modules go to the project folder:
 
@@ -16,25 +14,47 @@ To build all the modules go to the project folder:
 mvn clean install
 ```
 
-To build modules invidually go to module folder:
+To build modules individually go to module folder:
 
 
 ```maven
 mvn clean install
 ```
 
-
 ## Usage
----------
 
-### 9 Modules:
-#### OpenLR - parent: OpenLR - open standard for location referencing
-#### OpenLR - encoder:	The encoder package holds the reference implementation for the OpenLR encoder. It takes a (map-dependent) location as input and generates a corresponding (map-agnostic) location reference. This package uses the OpenLR map package and the OpenLR data package.
-#### OpenLR - map:	The map package consists of the map interface and map tools being used by the OpenLR encoder and decoder. The user of this package needs to implement the required methods and needs to translate the internal data structure to the OpenLR map interface.
-#### OpenLR - maploader-tt-sqlite:	This library provides an access layer which enables OpenLR to use TomTom Digital Maps in SQLite Format.
-#### OpenLR - decoder:	The decoder package holds the reference implementation for the OpenLR decoder. It takes a (map-agnostic) location reference as input and finds back a corresponding (map-dependent) location reference. This package uses the OpenLR map package and the OpenLR binary package
-#### OpenLR - data:	The OpenLR data package comprises interfaces for OpenLR location references and also interfaces for encoding and decoding the internal data into a defined physical format and the other way round.
-#### OpenLR - xml:	OpenLR XML physical format
-#### OpenLR - binary:	The binary package consists of classes for reading and writing binary location reference data. The OpenLR encoder uses this package to create a binary representation of a location reference. The OpenLR decoder uses this package to receive and decode binary location reference data.
-#### OpenLR - datex2:	OpenLR - open standard for location referencing
-OpenLR
+There are 9 modules:
+
+### `encoder`
+The encoder package holds the reference implementation for the OpenLR encoder. 
+It takes a (map-dependent) location as input and generates a corresponding (map-agnostic) 
+location reference. This package uses the OpenLR map package and the OpenLR data package.
+
+### `map`
+The map package consists of the map interface and map tools being used by the 
+OpenLR encoder and decoder. The user of this package needs to implement the required 
+methods and needs to translate the internal data structure to the OpenLR map interface.
+
+### `maploader-tt-sqlite`
+This library provides an access layer which enables OpenLR to use
+TomTom Digital Maps in SQLite Format.
+
+### `decoder`
+The decoder package holds the reference implementation for the OpenLR decoder. 
+It takes a (map-agnostic) location reference as input and finds back a corresponding (map-dependent) 
+location reference. This package uses the OpenLR map package and the OpenLR binary package.
+
+### `data`
+The OpenLR data package comprises interfaces for OpenLR location references and also 
+interfaces for encoding and decoding the internal data into a defined physical format and the 
+other way round.
+
+### `xml`
+OpenLR XML physical format.
+
+### `binary`
+This package consists of classes for reading and writing binary location. 
+reference data. The OpenLR encoder uses this package to create a binary representation of a location reference. The OpenLR decoder uses this package to receive and decode binary location reference data.
+
+### `datex2`
+This package deals with Datex2 data.

--- a/binary/pom.xml
+++ b/binary/pom.xml
@@ -3,9 +3,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>openlr</groupId>
+        <groupId>org.openlr</groupId>
         <artifactId>openlr</artifactId>
-        <version>1.4.3-SNAPSHOT</version>
+        <version>1.4.3</version>
     </parent>
 
     <artifactId>binary</artifactId>
@@ -21,13 +21,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>openlr</groupId>
+            <groupId>org.openlr</groupId>
             <artifactId>data</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>openlr</groupId>
+            <groupId>org.openlr</groupId>
             <artifactId>map</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -48,7 +48,7 @@
         </dependency>
 
         <dependency>
-            <groupId>openlr</groupId>
+            <groupId>org.openlr</groupId>
             <artifactId>data</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -3,9 +3,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>openlr</groupId>
+        <groupId>org.openlr</groupId>
         <artifactId>openlr</artifactId>
-        <version>1.4.3-SNAPSHOT</version>
+        <version>1.4.3</version>
     </parent>
 
     <artifactId>data</artifactId>
@@ -18,7 +18,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>openlr</groupId>
+            <groupId>org.openlr</groupId>
             <artifactId>map</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -49,7 +49,7 @@
         </dependency>
 
         <dependency>
-            <groupId>openlr</groupId>
+            <groupId>org.openlr</groupId>
             <artifactId>map</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>

--- a/datex2/pom.xml
+++ b/datex2/pom.xml
@@ -3,9 +3,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>openlr</groupId>
+        <groupId>org.openlr</groupId>
         <artifactId>openlr</artifactId>
-        <version>1.4.3-SNAPSHOT</version>
+        <version>1.4.3</version>
     </parent>
 
     <artifactId>datex2</artifactId>
@@ -13,13 +13,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>openlr</groupId>
+            <groupId>org.openlr</groupId>
             <artifactId>data</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>openlr</groupId>
+            <groupId>org.openlr</groupId>
             <artifactId>map</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -30,7 +30,7 @@
         </dependency>
 
         <dependency>
-            <groupId>openlr</groupId>
+            <groupId>org.openlr</groupId>
             <artifactId>data</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>

--- a/decoder/pom.xml
+++ b/decoder/pom.xml
@@ -3,9 +3,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>openlr</groupId>
+        <groupId>org.openlr</groupId>
         <artifactId>openlr</artifactId>
-        <version>1.4.3-SNAPSHOT</version>
+        <version>1.4.3</version>
     </parent>
 
     <artifactId>decoder</artifactId>
@@ -19,13 +19,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>openlr</groupId>
+            <groupId>org.openlr</groupId>
             <artifactId>map</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>openlr</groupId>
+            <groupId>org.openlr</groupId>
             <version>${project.version}</version>
             <artifactId>data</artifactId>
         </dependency>
@@ -46,7 +46,7 @@
         </dependency>
 
         <dependency>
-            <groupId>openlr</groupId>
+            <groupId>org.openlr</groupId>
             <artifactId>map</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>
@@ -54,7 +54,7 @@
         </dependency>
 
         <dependency>
-            <groupId>openlr</groupId>
+            <groupId>org.openlr</groupId>
             <artifactId>data</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>
@@ -62,7 +62,7 @@
         </dependency>
 
         <dependency>
-            <groupId>openlr</groupId>
+            <groupId>org.openlr</groupId>
             <artifactId>maploader-tt-sqlite</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/encoder/pom.xml
+++ b/encoder/pom.xml
@@ -3,9 +3,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>openlr</groupId>
+        <groupId>org.openlr</groupId>
         <artifactId>openlr</artifactId>
-        <version>1.4.3-SNAPSHOT</version>
+        <version>1.4.3</version>
     </parent>
 
     <artifactId>encoder</artifactId>
@@ -19,13 +19,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>openlr</groupId>
+            <groupId>org.openlr</groupId>
             <artifactId>map</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>openlr</groupId>
+            <groupId>org.openlr</groupId>
             <artifactId>data</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -51,7 +51,7 @@
         </dependency>
 
         <dependency>
-            <groupId>openlr</groupId>
+            <groupId>org.openlr</groupId>
             <artifactId>map</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>
@@ -59,7 +59,7 @@
         </dependency>
 
         <dependency>
-            <groupId>openlr</groupId>
+            <groupId>org.openlr</groupId>
             <artifactId>data</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>

--- a/map/pom.xml
+++ b/map/pom.xml
@@ -3,9 +3,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>openlr</groupId>
+        <groupId>org.openlr</groupId>
         <artifactId>openlr</artifactId>
-        <version>1.4.3-SNAPSHOT</version>
+        <version>1.4.3</version>
     </parent>
 
     <artifactId>map</artifactId>

--- a/maploader-tt-sqlite/pom.xml
+++ b/maploader-tt-sqlite/pom.xml
@@ -4,9 +4,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>openlr</groupId>
+        <groupId>org.openlr</groupId>
         <artifactId>openlr</artifactId>
-        <version>1.4.3-SNAPSHOT</version>
+        <version>1.4.3</version>
     </parent>
 
     <artifactId>maploader-tt-sqlite</artifactId>
@@ -18,7 +18,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>openlr</groupId>
+            <groupId>org.openlr</groupId>
             <artifactId>map</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2,10 +2,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>openlr</groupId>
+    <groupId>org.openlr</groupId>
     <artifactId>openlr</artifactId>
+
     <packaging>pom</packaging>
-    <version>1.4.3-SNAPSHOT</version>
+    <version>1.4.3</version>
+
+    <name>OpenLR</name>
 
     <url>http://www.openlr.org</url>
     <description>OpenLR - open standard for location referencing</description>
@@ -33,25 +36,241 @@
         </license>
     </licenses>
 
-    <modules>
-        <module>encoder</module>
-        <module>map</module>
-        <module>maploader-tt-sqlite</module>
-        <module>decoder</module>
-        <module>data</module>
-        <module>xml</module>
-        <module>binary</module>
-        <module>datex2</module>
-    </modules>
+    <scm>
+        <url>http://github.com/tomtom-international/openlr</url>
+    </scm>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
+    <distributionManagement>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/releases</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <modules>
+        <module>binary</module>
+        <module>data</module>
+        <module>datex2</module>
+        <module>decoder</module>
+        <module>encoder</module>
+        <module>map</module>
+        <module>maploader-tt-sqlite</module>
+        <module>xml</module>
+    </modules>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>cobertura-maven-plugin</artifactId>
+                    <version>2.6</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.eluder.coveralls</groupId>
+                    <artifactId>coveralls-maven-plugin</artifactId>
+                    <version>4.3.0</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.1.2</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-project-info-reports-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.7.1</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.6</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <configuration>
+                    <check/>
+                    <format>xml</format>
+                    <maxmem>256m</maxmem>
+                    <!-- aggregated reports for multi-module projects -->
+                    <aggregate>true</aggregate>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.8</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </reporting>
+
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>binary</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>data</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>datex2</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>decoder</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>encoder</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>map</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>maploader-tt-sqlite</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>xml</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>commons-configuration</groupId>
                 <artifactId>commons-configuration</artifactId>
@@ -125,69 +344,4 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.1.2</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>3.7.1</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>3.0.0</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>cobertura-maven-plugin</artifactId>
-                    <version>2.6</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.eluder.coveralls</groupId>
-                    <artifactId>coveralls-maven-plugin</artifactId>
-                    <version>4.3.0</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-site-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <configuration>
-                    <check/>
-                    <format>xml</format>
-                    <maxmem>256m</maxmem>
-                    <!-- aggregated reports for multi-module projects -->
-                    <aggregate>true</aggregate>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.eluder.coveralls</groupId>
-                <artifactId>coveralls-maven-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -3,9 +3,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>openlr</groupId>
+        <groupId>org.openlr</groupId>
         <artifactId>openlr</artifactId>
-        <version>1.4.3-SNAPSHOT</version>
+        <version>1.4.3</version>
     </parent>
 
     <artifactId>xml</artifactId>
@@ -15,13 +15,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>openlr</groupId>
+            <groupId>org.openlr</groupId>
             <artifactId>map</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>openlr</groupId>
+            <groupId>org.openlr</groupId>
             <artifactId>data</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -37,7 +37,7 @@
         </dependency>
 
         <dependency>
-            <groupId>openlr</groupId>
+            <groupId>org.openlr</groupId>
             <artifactId>data</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>


### PR DESCRIPTION
This PR prepares the POMs to push artefacts to Maven Central.
What still needs to be done:
* Fix all Javadoc errors, when you run `mvn site:site`. Either remove the offending Javadoc or fix it. This is required for the Nexus plugin.