### PR TITLE
feat: A non-junction node factor to scale the node rating down for non-junction nodes

### DIFF
--- a/decoder/src/main/java/openlr/decoder/properties/OpenLRDecoderProperties.java
+++ b/decoder/src/main/java/openlr/decoder/properties/OpenLRDecoderProperties.java
@@ -115,6 +115,9 @@ public class OpenLRDecoderProperties {
     /** The calc affected lines. */
     private final boolean calcAffectedLines;
 
+    /** The artificial node factor. */
+    private final float artificialNodeFactor;
+
     /** The lines directly factor. */
     private final float linesDirectlyFactor;
 
@@ -139,6 +142,8 @@ public class OpenLRDecoderProperties {
                 OpenLRDecoderProperty.NODE_FACTOR);
         lineFactor = OpenLRPropertyAccess.getIntegerPropertyValue(config,
                 OpenLRDecoderProperty.LINE_FACTOR);
+        artificialNodeFactor = OpenLRPropertyAccess.getFloatPropertyValue(config,
+                OpenLRDecoderProperty.ARTIFICIAL_NODE_FACTOR);
         frcVariance = OpenLRPropertyAccess.getIntegerPropertyValue(config,
                 OpenLRDecoderProperty.FRC_VARIANCE);
         minimumAcceptedRating = OpenLRPropertyAccess.getIntegerPropertyValue(
@@ -229,6 +234,15 @@ public class OpenLRDecoderProperties {
      */
     public final int getLineFactor() {
         return lineFactor;
+    }
+
+    /**
+     * Get the artificial node factor
+     *
+     * @return the artificial node factor
+     */
+    public final double getArtificialNodeFactor() {
+        return artificialNodeFactor;
     }
 
     /**

--- a/decoder/src/main/java/openlr/decoder/properties/OpenLRDecoderProperties.java
+++ b/decoder/src/main/java/openlr/decoder/properties/OpenLRDecoderProperties.java
@@ -115,8 +115,8 @@ public class OpenLRDecoderProperties {
     /** The calc affected lines. */
     private final boolean calcAffectedLines;
 
-    /** The artificial node factor. */
-    private final float artificialNodeFactor;
+    /** The non junction node factor. */
+    private final float nonJunctionNodeFactor;
 
     /** The lines directly factor. */
     private final float linesDirectlyFactor;
@@ -142,8 +142,8 @@ public class OpenLRDecoderProperties {
                 OpenLRDecoderProperty.NODE_FACTOR);
         lineFactor = OpenLRPropertyAccess.getIntegerPropertyValue(config,
                 OpenLRDecoderProperty.LINE_FACTOR);
-        artificialNodeFactor = OpenLRPropertyAccess.getFloatPropertyValue(config,
-                OpenLRDecoderProperty.ARTIFICIAL_NODE_FACTOR);
+        nonJunctionNodeFactor = OpenLRPropertyAccess.getFloatPropertyValue(config,
+                OpenLRDecoderProperty.NON_JUNCTION_NODE_FACTOR);
         frcVariance = OpenLRPropertyAccess.getIntegerPropertyValue(config,
                 OpenLRDecoderProperty.FRC_VARIANCE);
         minimumAcceptedRating = OpenLRPropertyAccess.getIntegerPropertyValue(
@@ -237,16 +237,16 @@ public class OpenLRDecoderProperties {
     }
 
     /**
-     * Get the artificial node factor. This is a value between 0 and 1 and is the scaling value to apply
-     * to the node rating during decoding if the node is an artificial node. An artificial node is a node that is not a junction.
+     * Get the non-junction node factor. This is a value between 0 and 1 and is the scaling value to apply
+     * during decoding to the score of nodes that are not junctions.
      *
-     * By default the artificial node factor is 1, meaning that artificial nodes are not penalised. To apply a penalty to
-     * artificial nodes, reduce the artificial node factor to a value under 0.
+     * By default the non-junction node factor is 1, meaning that non-junction nodes are not penalised.
+     * To apply a penalty to non-junction nodes, reduce the non-junction node factor to a value under 1.
      *
-     * @return the artificial node factor
+     * @return the non-junction node factor
      */
-    public final double getArtificialNodeFactor() {
-        return artificialNodeFactor;
+    public final float getNonJunctionNodeFactor() {
+        return nonJunctionNodeFactor;
     }
 
     /**

--- a/decoder/src/main/java/openlr/decoder/properties/OpenLRDecoderProperties.java
+++ b/decoder/src/main/java/openlr/decoder/properties/OpenLRDecoderProperties.java
@@ -237,7 +237,11 @@ public class OpenLRDecoderProperties {
     }
 
     /**
-     * Get the artificial node factor
+     * Get the artificial node factor. This is a value between 0 and 1 and is the scaling value to apply
+     * to the node rating during decoding if the node is an artificial node. An artificial node is a node that is not a junction.
+     *
+     * By default the artificial node factor is 1, meaning that artificial nodes are not penalised. To apply a penalty to
+     * artificial nodes, reduce the artificial node factor to a value under 0.
      *
      * @return the artificial node factor
      */

--- a/decoder/src/main/java/openlr/decoder/properties/OpenLRDecoderProperty.java
+++ b/decoder/src/main/java/openlr/decoder/properties/OpenLRDecoderProperty.java
@@ -84,6 +84,9 @@ public enum OpenLRDecoderProperty implements OpenLRProperty {
     /** The LIN e_ factor. */
     LINE_FACTOR("LineFactor", PropertyType.INTEGER, 3),
 
+    /** Artificial node factor */
+    ARTIFICIAL_NODE_FACTOR("ArtificialNodeFactor", PropertyType.FLOAT, 1.0f),
+
     /** The FR c_ vairance. */
     FRC_VARIANCE("FRC_Variance", PropertyType.INTEGER, 2),
 

--- a/decoder/src/main/java/openlr/decoder/properties/OpenLRDecoderProperty.java
+++ b/decoder/src/main/java/openlr/decoder/properties/OpenLRDecoderProperty.java
@@ -84,8 +84,8 @@ public enum OpenLRDecoderProperty implements OpenLRProperty {
     /** The LIN e_ factor. */
     LINE_FACTOR("LineFactor", PropertyType.INTEGER, 3),
 
-    /** Artificial node factor */
-    ARTIFICIAL_NODE_FACTOR("ArtificialNodeFactor", PropertyType.FLOAT, 1.0f),
+    /** Non junction node factor */
+    NON_JUNCTION_NODE_FACTOR("NonJunctionNodeFactor", PropertyType.FLOAT, 1.0f),
 
     /** The FR c_ vairance. */
     FRC_VARIANCE("FRC_Variance", PropertyType.INTEGER, 2),

--- a/decoder/src/main/java/openlr/decoder/rating/OpenLRRatingImpl.java
+++ b/decoder/src/main/java/openlr/decoder/rating/OpenLRRatingImpl.java
@@ -123,8 +123,8 @@ public class OpenLRRatingImpl implements OpenLRRating {
 
         int nodeRating = calculateDistanceRating(properties, distance);
 
-        if (shouldApplyArtificialNodeFactor(line, dir, projectionAlongLine)) {
-            nodeRating = (int) (properties.getArtificialNodeFactor() * nodeRating);
+        if (shouldApplyNonJunctionNodeFactor(line, dir, projectionAlongLine)) {
+            nodeRating = (int) (properties.getNonJunctionNodeFactor() * nodeRating);
         }
 
         int bearingRating = calculateBearingRating(properties, p.getBearing(),
@@ -151,15 +151,15 @@ public class OpenLRRatingImpl implements OpenLRRating {
     }
 
     /**
-     * Determine whether to apply the artificial node factor to the node score
+     * Determine whether to apply the non-junction node factor to the node score
      *
      * @param line the line under consideration
      * @param dir the direction along the line
      * @param projectionAlongLine the projected distance along the line
-     * @return true if the artificial node factor is to be applied
+     * @return true if the non-junction node factor is to be applied
      */
-    private boolean shouldApplyArtificialNodeFactor(Line line, BearingDirection dir, int projectionAlongLine) {
-        // Only apply the artificial node factor when the LRP matches a node and not a line directly
+    private boolean shouldApplyNonJunctionNodeFactor(Line line, BearingDirection dir, int projectionAlongLine) {
+        // Only apply the non-junction node factor when the LRP matches a node and not a line directly
         if (projectionAlongLine > 0) {
             return false;
         }
@@ -167,18 +167,18 @@ public class OpenLRRatingImpl implements OpenLRRating {
         // Find the node to check
         Node node = dir == BearingDirection.IN_DIRECTION ? line.getStartNode() : line.getEndNode();
 
-        // Check if the node is artificial
-        return isArtificialNode(node);
+        // Check if the node is not a junction
+        return !isJunction(node);
     }
 
     /**
-     * Check if a node is an artificial node.  Artificial nodes are nodes which are directly connected to only 2 other nodes.
+     * Check if a node is a junction. Junction nodes are nodes which are directly connected to more than 2 nodes.
      *
      * @param node the node to check
-     * @return true if the node is artificial
+     * @return true if the node is a junction
      */
-    private boolean isArtificialNode(Node node) {
-        return getConnectedNodeCount(node) == 2;
+    private boolean isJunction(Node node) {
+        return getConnectedNodeCount(node) > 2;
     }
 
     /**

--- a/decoder/src/test/java/openlr/decoder/data/OpenLRRatingImplTest.java
+++ b/decoder/src/test/java/openlr/decoder/data/OpenLRRatingImplTest.java
@@ -60,6 +60,7 @@ import openlr.map.FunctionalRoadClass;
 import openlr.map.Line;
 import openlr.map.MapDatabase;
 import openlr.properties.OpenLRPropertiesReader;
+import org.apache.commons.configuration.BaseConfiguration;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.testng.annotations.BeforeTest;
@@ -93,11 +94,26 @@ public class OpenLRRatingImplTest {
     /** The expected result of rating test #3. */
     private static final int EXPECTED_RESULT_RATING_3 = 644;
 
+    /** The artificial node factor to apply for tests */
+    private static final float ARTIFICIAL_NODE_FACTOR = 0.8f;
+
+    /** The expected result of rating test with real node with no artificial node factor. */
+    private static final int EXPECTED_RESULT_RATING_REAL_NODE_NO_ARTIFICIAL_NODE_FACTOR = 933;
+    /** The expected result of rating test with real node with an artificial node factor. */
+    private static final int EXPECTED_RESULT_RATING_REAL_NODE_ARTIFICIAL_NODE_FACTOR = 933;
+    /** The expected result of rating test with artificial node with no artificial node factor. */
+    private static final int EXPECTED_RESULT_RATING_ARTIFICIAL_NODE_NO_ARTIFICIAL_NODE_FACTOR = 783;
+    /** The expected result of rating test with artificial node with an artificial node factor. */
+    private static final int EXPECTED_RESULT_RATING_ARTIFICIAL_NODE_ARTIFICIAL_NODE_FACTOR = 729;
+
     /** The distance value of rating test #1. */
     private static final int DISTANCE_RATING_1 = 14;
     /** The distance value of rating test #2. */
     private static final int DISTANCE_RATING_2 = 3;
 
+
+    /** The ID of line 4 of the test map. */
+    private static final int TEST_LINE_4 = 4;
     /** The ID of line 10 of the test map. */
     private static final int TEST_LINE_10 = 10;
     /** The ID of line 26 of the test map. */
@@ -113,6 +129,8 @@ public class OpenLRRatingImplTest {
     private LocationReferencePoint point1;
     /** The mocked {@link LocRefPoint} #2. */
     private LocationReferencePoint point2;
+    /** The line object 4 of the test map. */
+    private Line line4;
     /** The line object 10 of the test map. */
     private Line line10;
     /** The line object 26 of the test map. */
@@ -126,6 +144,7 @@ public class OpenLRRatingImplTest {
         TestData td = TestData.getInstance();
         MapDatabase mdb = td.getMapDatabase();
 
+        line4 = mdb.getLine(TEST_LINE_4);
         line10 = mdb.getLine(TEST_LINE_10);
         line26 = mdb.getLine(TEST_LINE_26);
 
@@ -230,6 +249,84 @@ public class OpenLRRatingImplTest {
             int rating = RATING_FUNCTION.getRating(getProperties(),
                     DISTANCE_RATING_2, point2, line26, PROJECTION_LINE_26);
             assertEquals(EXPECTED_RESULT_RATING_3, rating);
+
+        } catch (OpenLRProcessingException e) {
+            fail("Unexpected exception!", e);
+        }
+    }
+
+    /**
+     * Rating test of real node when applying no artificial node factor
+     */
+    @Test
+    public final void testRatingRealNodeNoArtificialNodeFactor() {
+
+        try {
+            BaseConfiguration configuration = new BaseConfiguration();
+            OpenLRDecoderProperties properties = new OpenLRDecoderProperties(configuration);
+
+            int rating = RATING_FUNCTION.getRating(properties,
+                    DISTANCE_RATING_1, point1, line10, 0);
+            assertEquals(rating, EXPECTED_RESULT_RATING_REAL_NODE_NO_ARTIFICIAL_NODE_FACTOR);
+
+        } catch (OpenLRProcessingException e) {
+            fail("Unexpected exception!", e);
+        }
+    }
+
+    /**
+     * Rating test of real node when applying an artificial node factor
+     */
+    @Test
+    public final void testRatingRealNodeArtificialNodeFactor() {
+
+        try {
+            BaseConfiguration configuration = new BaseConfiguration();
+            configuration.setProperty("ArtificialNodeFactor", ARTIFICIAL_NODE_FACTOR);
+            OpenLRDecoderProperties properties = new OpenLRDecoderProperties(configuration);
+
+            int rating = RATING_FUNCTION.getRating(properties,
+                    DISTANCE_RATING_1, point1, line10, 0);
+            assertEquals(rating, EXPECTED_RESULT_RATING_REAL_NODE_ARTIFICIAL_NODE_FACTOR);
+
+        } catch (OpenLRProcessingException e) {
+            fail("Unexpected exception!", e);
+        }
+    }
+
+    /**
+     * Rating test of artificial node when applying no artificial node factor
+     */
+    @Test
+    public final void testRatingArtificialNodeNoArtificialNodeFactor() {
+
+        try {
+            BaseConfiguration configuration = new BaseConfiguration();
+            OpenLRDecoderProperties properties = new OpenLRDecoderProperties(configuration);
+
+            int rating = RATING_FUNCTION.getRating(properties,
+                    DISTANCE_RATING_1, point1, line4, 0);
+            assertEquals(rating, EXPECTED_RESULT_RATING_ARTIFICIAL_NODE_NO_ARTIFICIAL_NODE_FACTOR);
+
+        } catch (OpenLRProcessingException e) {
+            fail("Unexpected exception!", e);
+        }
+    }
+
+    /**
+     * Rating test of artificial node when applying no artificial node factor
+     */
+    @Test
+    public final void testRatingArtificialNodeArtificialNodeFactor() {
+
+        try {
+            BaseConfiguration configuration = new BaseConfiguration();
+            configuration.setProperty("ArtificialNodeFactor", ARTIFICIAL_NODE_FACTOR);
+            OpenLRDecoderProperties properties = new OpenLRDecoderProperties(configuration);
+
+            int rating = RATING_FUNCTION.getRating(properties,
+                    DISTANCE_RATING_1, point1, line4, 0);
+            assertEquals(rating, EXPECTED_RESULT_RATING_ARTIFICIAL_NODE_ARTIFICIAL_NODE_FACTOR);
 
         } catch (OpenLRProcessingException e) {
             fail("Unexpected exception!", e);

--- a/decoder/src/test/java/openlr/decoder/data/OpenLRRatingImplTest.java
+++ b/decoder/src/test/java/openlr/decoder/data/OpenLRRatingImplTest.java
@@ -314,7 +314,7 @@ public class OpenLRRatingImplTest {
     }
 
     /**
-     * Rating test of artificial node when applying no artificial node factor
+     * Rating test of artificial node when applying an artificial node factor
      */
     @Test
     public final void testRatingArtificialNodeArtificialNodeFactor() {

--- a/decoder/src/test/java/openlr/decoder/data/OpenLRRatingImplTest.java
+++ b/decoder/src/test/java/openlr/decoder/data/OpenLRRatingImplTest.java
@@ -211,126 +211,84 @@ public class OpenLRRatingImplTest {
      * Rating test #1.
      */
     @Test
-    public final void testRating1() {
-
-        try {
-            int rating = RATING_FUNCTION.getRating(getProperties(),
-                    DISTANCE_RATING_1, point1, line10, 0);
-            assertEquals(EXPECTED_RESULT_RATING_1, rating);
-
-        } catch (OpenLRProcessingException e) {
-            fail("Unexpected exception!", e);
-        }
+    public final void testRating1() throws OpenLRProcessingException {
+        int rating = RATING_FUNCTION.getRating(getProperties(),
+                DISTANCE_RATING_1, point1, line10, 0);
+        assertEquals(EXPECTED_RESULT_RATING_1, rating);
     }
 
     /**
      * Rating test #2.
      */
     @Test
-    public final void testRating2() {
-
-        try {
-            int rating = RATING_FUNCTION.getRating(getProperties(),
-                    DISTANCE_RATING_2, point2, line10, 0);
-            assertEquals(EXPECTED_RESULT_RATING_2, rating);
-
-        } catch (OpenLRProcessingException e) {
-            fail("Unexpected exception!", e);
-        }
+    public final void testRating2() throws OpenLRProcessingException {
+        int rating = RATING_FUNCTION.getRating(getProperties(),
+                DISTANCE_RATING_2, point2, line10, 0);
+        assertEquals(EXPECTED_RESULT_RATING_2, rating);
     }
 
     /**
      * Rating test #3.
      */
     @Test
-    public final void testRating3() {
-
-        try {
-            int rating = RATING_FUNCTION.getRating(getProperties(),
-                    DISTANCE_RATING_2, point2, line26, PROJECTION_LINE_26);
-            assertEquals(EXPECTED_RESULT_RATING_3, rating);
-
-        } catch (OpenLRProcessingException e) {
-            fail("Unexpected exception!", e);
-        }
+    public final void testRating3() throws OpenLRProcessingException {
+        int rating = RATING_FUNCTION.getRating(getProperties(),
+                DISTANCE_RATING_2, point2, line26, PROJECTION_LINE_26);
+        assertEquals(EXPECTED_RESULT_RATING_3, rating);
     }
 
     /**
      * Rating test of junction node when applying no non-junction node factor
      */
     @Test
-    public final void testRatingJunctionNodeNoNonJunctionNodeFactor() {
+    public final void testRatingJunctionNodeNoNonJunctionNodeFactor() throws OpenLRProcessingException {
+        BaseConfiguration configuration = new BaseConfiguration();
+        OpenLRDecoderProperties properties = new OpenLRDecoderProperties(configuration);
 
-        try {
-            BaseConfiguration configuration = new BaseConfiguration();
-            OpenLRDecoderProperties properties = new OpenLRDecoderProperties(configuration);
-
-            int rating = RATING_FUNCTION.getRating(properties,
-                    DISTANCE_RATING_1, point1, line10, 0);
-            assertEquals(rating, EXPECTED_RESULT_RATING_JUNCTION_NODE_NO_NON_JUNCTION_NODE_FACTOR);
-
-        } catch (OpenLRProcessingException e) {
-            fail("Unexpected exception!", e);
-        }
+        int rating = RATING_FUNCTION.getRating(properties,
+                DISTANCE_RATING_1, point1, line10, 0);
+        assertEquals(rating, EXPECTED_RESULT_RATING_JUNCTION_NODE_NO_NON_JUNCTION_NODE_FACTOR);
     }
 
     /**
      * Rating test of junction node when applying a non-junction node factor
      */
     @Test
-    public final void testRatingJunctionNodeNonJunctionNodeFactor() {
+    public final void testRatingJunctionNodeNonJunctionNodeFactor() throws OpenLRProcessingException {
+        BaseConfiguration configuration = new BaseConfiguration();
+        configuration.setProperty("NonJunctionNodeFactor", NON_JUNCTION_NODE_FACTOR);
+        OpenLRDecoderProperties properties = new OpenLRDecoderProperties(configuration);
 
-        try {
-            BaseConfiguration configuration = new BaseConfiguration();
-            configuration.setProperty("NonJunctionNodeFactor", NON_JUNCTION_NODE_FACTOR);
-            OpenLRDecoderProperties properties = new OpenLRDecoderProperties(configuration);
-
-            int rating = RATING_FUNCTION.getRating(properties,
-                    DISTANCE_RATING_1, point1, line10, 0);
-            assertEquals(rating, EXPECTED_RESULT_RATING_JUNCTION_NODE_NON_JUNCTION_NODE_FACTOR);
-
-        } catch (OpenLRProcessingException e) {
-            fail("Unexpected exception!", e);
-        }
+        int rating = RATING_FUNCTION.getRating(properties,
+                DISTANCE_RATING_1, point1, line10, 0);
+        assertEquals(rating, EXPECTED_RESULT_RATING_JUNCTION_NODE_NON_JUNCTION_NODE_FACTOR);
     }
 
     /**
      * Rating test of non-junction node when applying no non-junction node factor
      */
     @Test
-    public final void testRatingNonJunctionNodeNoNonJunctionNodeFactor() {
+    public final void testRatingNonJunctionNodeNoNonJunctionNodeFactor() throws OpenLRProcessingException {
+        BaseConfiguration configuration = new BaseConfiguration();
+        OpenLRDecoderProperties properties = new OpenLRDecoderProperties(configuration);
 
-        try {
-            BaseConfiguration configuration = new BaseConfiguration();
-            OpenLRDecoderProperties properties = new OpenLRDecoderProperties(configuration);
-
-            int rating = RATING_FUNCTION.getRating(properties,
-                    DISTANCE_RATING_1, point1, line4, 0);
-            assertEquals(rating, EXPECTED_RESULT_RATING_NON_JUNCTION_NODE_NO_NON_JUNCTION_NODE_FACTOR);
-
-        } catch (OpenLRProcessingException e) {
-            fail("Unexpected exception!", e);
-        }
+        int rating = RATING_FUNCTION.getRating(properties,
+                DISTANCE_RATING_1, point1, line4, 0);
+        assertEquals(rating, EXPECTED_RESULT_RATING_NON_JUNCTION_NODE_NO_NON_JUNCTION_NODE_FACTOR);
     }
 
     /**
      * Rating test of non-junction node when applying a non-junction node factor
      */
     @Test
-    public final void testRatingNonJunctionNodeNonJunctionNodeFactor() {
+    public final void testRatingNonJunctionNodeNonJunctionNodeFactor() throws OpenLRProcessingException {
+        BaseConfiguration configuration = new BaseConfiguration();
+        configuration.setProperty("NonJunctionNodeFactor", NON_JUNCTION_NODE_FACTOR);
+        OpenLRDecoderProperties properties = new OpenLRDecoderProperties(configuration);
 
-        try {
-            BaseConfiguration configuration = new BaseConfiguration();
-            configuration.setProperty("NonJunctionNodeFactor", NON_JUNCTION_NODE_FACTOR);
-            OpenLRDecoderProperties properties = new OpenLRDecoderProperties(configuration);
-
-            int rating = RATING_FUNCTION.getRating(properties,
-                    DISTANCE_RATING_1, point1, line4, 0);
-            assertEquals(rating, EXPECTED_RESULT_RATING_NON_JUNCTION_NODE_NON_JUNCTION_NODE_FACTOR);
-
-        } catch (OpenLRProcessingException e) {
-            fail("Unexpected exception!", e);
-        }
+        int rating = RATING_FUNCTION.getRating(properties,
+                DISTANCE_RATING_1, point1, line4, 0);
+        assertEquals(rating, EXPECTED_RESULT_RATING_NON_JUNCTION_NODE_NON_JUNCTION_NODE_FACTOR);
     }
 
     /**

--- a/decoder/src/test/java/openlr/decoder/data/OpenLRRatingImplTest.java
+++ b/decoder/src/test/java/openlr/decoder/data/OpenLRRatingImplTest.java
@@ -94,17 +94,17 @@ public class OpenLRRatingImplTest {
     /** The expected result of rating test #3. */
     private static final int EXPECTED_RESULT_RATING_3 = 644;
 
-    /** The artificial node factor to apply for tests */
-    private static final float ARTIFICIAL_NODE_FACTOR = 0.8f;
+    /** The non-junction node factor to apply for tests */
+    private static final float NON_JUNCTION_NODE_FACTOR = 0.8f;
 
-    /** The expected result of rating test with real node with no artificial node factor. */
-    private static final int EXPECTED_RESULT_RATING_REAL_NODE_NO_ARTIFICIAL_NODE_FACTOR = 933;
-    /** The expected result of rating test with real node with an artificial node factor. */
-    private static final int EXPECTED_RESULT_RATING_REAL_NODE_ARTIFICIAL_NODE_FACTOR = 933;
-    /** The expected result of rating test with artificial node with no artificial node factor. */
-    private static final int EXPECTED_RESULT_RATING_ARTIFICIAL_NODE_NO_ARTIFICIAL_NODE_FACTOR = 783;
-    /** The expected result of rating test with artificial node with an artificial node factor. */
-    private static final int EXPECTED_RESULT_RATING_ARTIFICIAL_NODE_ARTIFICIAL_NODE_FACTOR = 729;
+    /** The expected result of rating test with junction node with no non-junction node factor. */
+    private static final int EXPECTED_RESULT_RATING_JUNCTION_NODE_NO_NON_JUNCTION_NODE_FACTOR = 933;
+    /** The expected result of rating test with junction node with a non-junction node factor. */
+    private static final int EXPECTED_RESULT_RATING_JUNCTION_NODE_NON_JUNCTION_NODE_FACTOR = 933;
+    /** The expected result of rating test with non-junction node with no non-junction node factor. */
+    private static final int EXPECTED_RESULT_RATING_NON_JUNCTION_NODE_NO_NON_JUNCTION_NODE_FACTOR = 783;
+    /** The expected result of rating test with non-junction node with a non-junction node factor. */
+    private static final int EXPECTED_RESULT_RATING_NON_JUNCTION_NODE_NON_JUNCTION_NODE_FACTOR = 729;
 
     /** The distance value of rating test #1. */
     private static final int DISTANCE_RATING_1 = 14;
@@ -256,10 +256,10 @@ public class OpenLRRatingImplTest {
     }
 
     /**
-     * Rating test of real node when applying no artificial node factor
+     * Rating test of junction node when applying no non-junction node factor
      */
     @Test
-    public final void testRatingRealNodeNoArtificialNodeFactor() {
+    public final void testRatingJunctionNodeNoNonJunctionNodeFactor() {
 
         try {
             BaseConfiguration configuration = new BaseConfiguration();
@@ -267,7 +267,7 @@ public class OpenLRRatingImplTest {
 
             int rating = RATING_FUNCTION.getRating(properties,
                     DISTANCE_RATING_1, point1, line10, 0);
-            assertEquals(rating, EXPECTED_RESULT_RATING_REAL_NODE_NO_ARTIFICIAL_NODE_FACTOR);
+            assertEquals(rating, EXPECTED_RESULT_RATING_JUNCTION_NODE_NO_NON_JUNCTION_NODE_FACTOR);
 
         } catch (OpenLRProcessingException e) {
             fail("Unexpected exception!", e);
@@ -275,19 +275,19 @@ public class OpenLRRatingImplTest {
     }
 
     /**
-     * Rating test of real node when applying an artificial node factor
+     * Rating test of junction node when applying a non-junction node factor
      */
     @Test
-    public final void testRatingRealNodeArtificialNodeFactor() {
+    public final void testRatingJunctionNodeNonJunctionNodeFactor() {
 
         try {
             BaseConfiguration configuration = new BaseConfiguration();
-            configuration.setProperty("ArtificialNodeFactor", ARTIFICIAL_NODE_FACTOR);
+            configuration.setProperty("NonJunctionNodeFactor", NON_JUNCTION_NODE_FACTOR);
             OpenLRDecoderProperties properties = new OpenLRDecoderProperties(configuration);
 
             int rating = RATING_FUNCTION.getRating(properties,
                     DISTANCE_RATING_1, point1, line10, 0);
-            assertEquals(rating, EXPECTED_RESULT_RATING_REAL_NODE_ARTIFICIAL_NODE_FACTOR);
+            assertEquals(rating, EXPECTED_RESULT_RATING_JUNCTION_NODE_NON_JUNCTION_NODE_FACTOR);
 
         } catch (OpenLRProcessingException e) {
             fail("Unexpected exception!", e);
@@ -295,10 +295,10 @@ public class OpenLRRatingImplTest {
     }
 
     /**
-     * Rating test of artificial node when applying no artificial node factor
+     * Rating test of non-junction node when applying no non-junction node factor
      */
     @Test
-    public final void testRatingArtificialNodeNoArtificialNodeFactor() {
+    public final void testRatingNonJunctionNodeNoNonJunctionNodeFactor() {
 
         try {
             BaseConfiguration configuration = new BaseConfiguration();
@@ -306,7 +306,7 @@ public class OpenLRRatingImplTest {
 
             int rating = RATING_FUNCTION.getRating(properties,
                     DISTANCE_RATING_1, point1, line4, 0);
-            assertEquals(rating, EXPECTED_RESULT_RATING_ARTIFICIAL_NODE_NO_ARTIFICIAL_NODE_FACTOR);
+            assertEquals(rating, EXPECTED_RESULT_RATING_NON_JUNCTION_NODE_NO_NON_JUNCTION_NODE_FACTOR);
 
         } catch (OpenLRProcessingException e) {
             fail("Unexpected exception!", e);
@@ -314,19 +314,19 @@ public class OpenLRRatingImplTest {
     }
 
     /**
-     * Rating test of artificial node when applying an artificial node factor
+     * Rating test of non-junction node when applying a non-junction node factor
      */
     @Test
-    public final void testRatingArtificialNodeArtificialNodeFactor() {
+    public final void testRatingNonJunctionNodeNonJunctionNodeFactor() {
 
         try {
             BaseConfiguration configuration = new BaseConfiguration();
-            configuration.setProperty("ArtificialNodeFactor", ARTIFICIAL_NODE_FACTOR);
+            configuration.setProperty("NonJunctionNodeFactor", NON_JUNCTION_NODE_FACTOR);
             OpenLRDecoderProperties properties = new OpenLRDecoderProperties(configuration);
 
             int rating = RATING_FUNCTION.getRating(properties,
                     DISTANCE_RATING_1, point1, line4, 0);
-            assertEquals(rating, EXPECTED_RESULT_RATING_ARTIFICIAL_NODE_ARTIFICIAL_NODE_FACTOR);
+            assertEquals(rating, EXPECTED_RESULT_RATING_NON_JUNCTION_NODE_NON_JUNCTION_NODE_FACTOR);
 
         } catch (OpenLRProcessingException e) {
             fail("Unexpected exception!", e);


### PR DESCRIPTION
We should score non-junction nodes less than junction nodes during decoding. The overwhelming majority of LRPs lie on junction nodes and we should prioritise searching for junction nodes during decoding.
* Introduced a `NonJunctionNodeFactor` setting to the decoder settings to scale down the node rating of non-junction nodes. By default this is `1.0` ie. do not scale.  This means the features is, by default, switched off. The user can turn on the feature by setting this value to anything other than 1.0.
* Applied the `NonJunctionNodeFactor` in the rating function.
* Added tests.