### PR TITLE
feat: Variable FRC variance

### DIFF
--- a/decoder/src/main/java/openlr/decoder/properties/OpenLRDecoderProperties.java
+++ b/decoder/src/main/java/openlr/decoder/properties/OpenLRDecoderProperties.java
@@ -265,7 +265,7 @@ public class OpenLRDecoderProperties {
      *
      * @return the frcVariance
      */
-    public final Integer getFrcVariance(FunctionalRoadClass frc) {
+    public final int getFrcVariance(FunctionalRoadClass frc) {
         return frcVariance.get(frc);
     }
 

--- a/decoder/src/main/java/openlr/decoder/properties/OpenLRDecoderProperties.java
+++ b/decoder/src/main/java/openlr/decoder/properties/OpenLRDecoderProperties.java
@@ -54,10 +54,13 @@ package openlr.decoder.properties;
 
 import openlr.OpenLRProcessingException;
 import openlr.decoder.rating.OpenLRRating.RatingCategory;
+import openlr.map.FunctionalRoadClass;
 import openlr.properties.OpenLRPropertyAccess;
 import org.apache.commons.configuration.Configuration;
 
 import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * The Class OpenLRDecoderProperties.
@@ -77,7 +80,7 @@ public class OpenLRDecoderProperties {
     private final int lineFactor;
 
     /** The frc variance. */
-    private final int frcVariance;
+    private final Map<FunctionalRoadClass, Integer> frcVariance;
 
     /** The minimum accepted rating. */
     private final int minimumAcceptedRating;
@@ -144,8 +147,16 @@ public class OpenLRDecoderProperties {
                 OpenLRDecoderProperty.LINE_FACTOR);
         nonJunctionNodeFactor = OpenLRPropertyAccess.getFloatPropertyValue(config,
                 OpenLRDecoderProperty.NON_JUNCTION_NODE_FACTOR);
-        frcVariance = OpenLRPropertyAccess.getIntegerPropertyValue(config,
-                OpenLRDecoderProperty.FRC_VARIANCE);
+
+        frcVariance = new HashMap<>();
+
+        for (FunctionalRoadClass frc : FunctionalRoadClass.values()) {
+            frcVariance.put(frc, OpenLRPropertyAccess.getIntegerPropertyValueFromMap(
+                    config,
+                    OpenLRDecoderProperty.FRC_VARIANCE,
+                    frc.name()));
+        }
+
         minimumAcceptedRating = OpenLRPropertyAccess.getIntegerPropertyValue(
                 config, OpenLRDecoderProperty.MIN_ACC_RATING);
         maxNumberRetries = OpenLRPropertyAccess.getIntegerPropertyValue(config,
@@ -254,8 +265,8 @@ public class OpenLRDecoderProperties {
      *
      * @return the frcVariance
      */
-    public final int getFrcVariance() {
-        return frcVariance;
+    public final Integer getFrcVariance(FunctionalRoadClass frc) {
+        return frcVariance.get(frc);
     }
 
     /**

--- a/decoder/src/main/java/openlr/decoder/properties/OpenLRDecoderProperties.java
+++ b/decoder/src/main/java/openlr/decoder/properties/OpenLRDecoderProperties.java
@@ -151,10 +151,11 @@ public class OpenLRDecoderProperties {
         frcVariance = new HashMap<>();
 
         for (FunctionalRoadClass frc : FunctionalRoadClass.values()) {
-            frcVariance.put(frc, OpenLRPropertyAccess.getIntegerPropertyValueFromMap(
+            int variance = OpenLRPropertyAccess.getIntegerPropertyValueFromMap(
                     config,
                     OpenLRDecoderProperty.FRC_VARIANCE,
-                    frc.name()));
+                    frc.name());
+            frcVariance.put(frc, variance);
         }
 
         minimumAcceptedRating = OpenLRPropertyAccess.getIntegerPropertyValue(

--- a/decoder/src/main/java/openlr/decoder/properties/OpenLRDecoderProperty.java
+++ b/decoder/src/main/java/openlr/decoder/properties/OpenLRDecoderProperty.java
@@ -52,9 +52,11 @@
  */
 package openlr.decoder.properties;
 
+import openlr.map.FunctionalRoadClass;
 import openlr.properties.OpenLRProperty;
 import openlr.properties.PropertyType;
 
+import java.util.Arrays;
 import java.util.HashMap;
 
 /**
@@ -87,8 +89,20 @@ public enum OpenLRDecoderProperty implements OpenLRProperty {
     /** Non junction node factor */
     NON_JUNCTION_NODE_FACTOR("NonJunctionNodeFactor", PropertyType.FLOAT, 1.0f),
 
-    /** The FR c_ vairance. */
-    FRC_VARIANCE("FRC_Variance", PropertyType.INTEGER, 2),
+    /** The FRC variance */
+    FRC_VARIANCE("FRC_Variance", PropertyType.INTEGER_BY_MAP,
+        new HashMap<String, Integer>() {
+        {
+            put("FRC_0", 2);
+            put("FRC_1", 2);
+            put("FRC_2", 2);
+            put("FRC_3", 2);
+            put("FRC_4", 2);
+            put("FRC_5", 2);
+            put("FRC_6", 2);
+            put("FRC_7", 2);
+        }
+    }),
 
     /** The MI n_ ac c_ rating. */
     MIN_ACC_RATING("MinimumAcceptedRating", PropertyType.INTEGER, 800),

--- a/decoder/src/main/java/openlr/decoder/properties/OpenLRDecoderProperty.java
+++ b/decoder/src/main/java/openlr/decoder/properties/OpenLRDecoderProperty.java
@@ -52,11 +52,9 @@
  */
 package openlr.decoder.properties;
 
-import openlr.map.FunctionalRoadClass;
 import openlr.properties.OpenLRProperty;
 import openlr.properties.PropertyType;
 
-import java.util.Arrays;
 import java.util.HashMap;
 
 /**

--- a/decoder/src/main/java/openlr/decoder/worker/AbstractDecoder.java
+++ b/decoder/src/main/java/openlr/decoder/worker/AbstractDecoder.java
@@ -240,7 +240,7 @@ public abstract class AbstractDecoder {
 
             if (lrp.getLfrc() != null
                     && frc.getID() > lrp.getLfrc().getID()
-                    + properties.getFrcVariance(lrp.getFRC())) {
+                    + properties.getFrcVariance(lrp.getLfrc())) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("line " + line.getID() + " ignored [low frc ("
                             + frc.getID() + ")]");

--- a/decoder/src/main/java/openlr/decoder/worker/AbstractDecoder.java
+++ b/decoder/src/main/java/openlr/decoder/worker/AbstractDecoder.java
@@ -240,7 +240,7 @@ public abstract class AbstractDecoder {
 
             if (lrp.getLfrc() != null
                     && frc.getID() > lrp.getLfrc().getID()
-                    + properties.getFrcVariance()) {
+                    + properties.getFrcVariance(lrp.getFRC())) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("line " + line.getID() + " ignored [low frc ("
                             + frc.getID() + ")]");
@@ -418,7 +418,7 @@ public abstract class AbstractDecoder {
         FunctionalRoadClass frc = line.getFRC();
         if (!p.isLastLRP()
                 && frc.getID() > p.getLfrc().getID()
-                + properties.getFrcVariance()) {
+                + properties.getFrcVariance(p.getLfrc())) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("line " + line.getID() + " ignored [low frc (" + frc.getID() + ")]");
             }
@@ -508,7 +508,7 @@ public abstract class AbstractDecoder {
                             + lrp.getDistanceToNext() + "m");
                 }
                 // determine the minimum frc for the path to be calculated
-                int lfrc = lrp.getLfrc().getID() + properties.getFrcVariance();
+                int lfrc = lrp.getLfrc().getID() + properties.getFrcVariance(lrp.getLfrc());
                 CandidateLine previousEndCandidate = null;
                 if (lrpPrev != null) {
                     previousEndCandidate = resolvedRoutes
@@ -823,7 +823,7 @@ public abstract class AbstractDecoder {
                 ppreviousCandidate, newCandidate, properties);
         RouteSearch.RouteSearchResult resultRedo = rsearchInner.calculateRoute(
                 newStart, newCandidate.getLine(), maxdistanceInner, lrpPrev
-                        .getLfrc().getID() + properties.getFrcVariance(),
+                        .getLfrc().getID() + properties.getFrcVariance(lrpPrev.getLfrc()),
                 lrp.isLastLRP());
         if (resultRedo == RouteSearch.RouteSearchResult.ROUTE_FOUND
                 && DecoderUtils.getMinDistanceNP(lrpPrev, properties) <= rsearchInner

--- a/decoder/src/main/resources/OpenLR-Decoder-Properties.xml
+++ b/decoder/src/main/resources/OpenLR-Decoder-Properties.xml
@@ -62,7 +62,7 @@
         <Good>12</Good>
         <Average>18</Average>
     </Bearing_Intervals>
-    <FRC_Variance>2</FRC_Variance>
+    <FRC_Variance></FRC_Variance>
     <MinimumAcceptedRating>700</MinimumAcceptedRating>
     <MaxNumberRetries>3</MaxNumberRetries>
     <SameLineDegradation>0.10</SameLineDegradation>

--- a/decoder/src/test/java/openlr/decoder/properties/DecoderPropertiesTest.java
+++ b/decoder/src/test/java/openlr/decoder/properties/DecoderPropertiesTest.java
@@ -52,6 +52,7 @@ package openlr.decoder.properties;
 
 import openlr.OpenLRProcessingException;
 import openlr.decoder.rating.OpenLRRating.RatingCategory;
+import openlr.map.FunctionalRoadClass;
 import openlr.properties.OpenLRPropertiesReader;
 import openlr.properties.OpenLRPropertyAccess;
 import org.apache.commons.configuration.Configuration;
@@ -82,7 +83,9 @@ public class DecoderPropertiesTest {
     /** The expected value for property 'node factor'. */
     private static final int NODE_FACTOR = 2;
     /** The expected value for property 'FRC variance'. */
-    private static final int FRC_VARIANCE = 2;
+    private static final int FRC_VARIANCE_TIGHT = 1;
+    private static final int FRC_VARIANCE_STANDARD = 2;
+    private static final int FRC_VARIANCE_LOOSE = 3;
     /** The expected value for property 'minimum accepted rating'. */
     private static final int MIN_ACCEPTED_RATING = 800;
     /** The expected value for property 'maximum node distance'. */
@@ -152,8 +155,24 @@ public class DecoderPropertiesTest {
                     OpenLRDecoderProperty.MAX_NODE_DIST), MAX_NODE_DISTANCE);
             assertEquals(OpenLRPropertyAccess.getIntegerPropertyValue(prop,
                     OpenLRDecoderProperty.MIN_ACC_RATING), MIN_ACCEPTED_RATING);
-            assertEquals(OpenLRPropertyAccess.getIntegerPropertyValue(prop,
-                    OpenLRDecoderProperty.FRC_VARIANCE), FRC_VARIANCE);
+
+            assertEquals(OpenLRPropertyAccess.getIntegerPropertyValueFromMap(prop,
+                    OpenLRDecoderProperty.FRC_VARIANCE, FunctionalRoadClass.FRC_0.name()), FRC_VARIANCE_TIGHT);
+            assertEquals(OpenLRPropertyAccess.getIntegerPropertyValueFromMap(prop,
+                    OpenLRDecoderProperty.FRC_VARIANCE, FunctionalRoadClass.FRC_1.name()), FRC_VARIANCE_TIGHT);
+            assertEquals(OpenLRPropertyAccess.getIntegerPropertyValueFromMap(prop,
+                    OpenLRDecoderProperty.FRC_VARIANCE, FunctionalRoadClass.FRC_2.name()), FRC_VARIANCE_STANDARD);
+            assertEquals(OpenLRPropertyAccess.getIntegerPropertyValueFromMap(prop,
+                    OpenLRDecoderProperty.FRC_VARIANCE, FunctionalRoadClass.FRC_3.name()), FRC_VARIANCE_STANDARD);
+            assertEquals(OpenLRPropertyAccess.getIntegerPropertyValueFromMap(prop,
+                    OpenLRDecoderProperty.FRC_VARIANCE, FunctionalRoadClass.FRC_4.name()), FRC_VARIANCE_LOOSE);
+            assertEquals(OpenLRPropertyAccess.getIntegerPropertyValueFromMap(prop,
+                    OpenLRDecoderProperty.FRC_VARIANCE, FunctionalRoadClass.FRC_5.name()), FRC_VARIANCE_LOOSE);
+            assertEquals(OpenLRPropertyAccess.getIntegerPropertyValueFromMap(prop,
+                    OpenLRDecoderProperty.FRC_VARIANCE, FunctionalRoadClass.FRC_6.name()), FRC_VARIANCE_LOOSE);
+            assertEquals(OpenLRPropertyAccess.getIntegerPropertyValueFromMap(prop,
+                    OpenLRDecoderProperty.FRC_VARIANCE, FunctionalRoadClass.FRC_7.name()), FRC_VARIANCE_LOOSE);
+
             assertEquals(OpenLRPropertyAccess.getIntegerPropertyValue(prop,
                     OpenLRDecoderProperty.NODE_FACTOR), NODE_FACTOR);
             assertEquals(OpenLRPropertyAccess.getIntegerPropertyValue(prop,

--- a/decoder/src/test/resources/OpenLR-Decoder-Properties.xml
+++ b/decoder/src/test/resources/OpenLR-Decoder-Properties.xml
@@ -60,7 +60,16 @@
         <Good>12</Good>
         <Average>18</Average>
     </Bearing_Intervals>
-    <FRC_Variance>2</FRC_Variance>
+    <FRC_Variance>
+        <FRC_0>1</FRC_0>
+        <FRC_1>1</FRC_1>
+        <FRC_2>2</FRC_2>
+        <FRC_3>2</FRC_3>
+        <FRC_4>3</FRC_4>
+        <FRC_5>3</FRC_5>
+        <FRC_6>3</FRC_6>
+        <FRC_7>3</FRC_7>
+    </FRC_Variance>
     <MinimumAcceptedRating>800</MinimumAcceptedRating>
     <MaxNumberRetries>3</MaxNumberRetries>
     <SameLineDegradation>0.10</SameLineDegradation>


### PR DESCRIPTION
Currently the `FRC_Variance` is a fixed value in the decoder settings.  This controls the tolerance for how much the FRC of candidate lines can differ from the FRC value in the `lfrc` property of a location reference point.

```xml
<FRC_Variance>2</FRC_Variance>
```

From experience, however, FRCs tend to match well on more important roads and less well on less important roads. This change allows the `FRC_Variance` to be set on a per-FRC basis via the decoder configuration properties eg.

```xml
 <FRC_Variance>
   <FRC_0>1</FRC_0>
   <FRC_1>1</FRC_1>
   <FRC_2>2</FRC_2>
   <FRC_3>2</FRC_3>
   <FRC_4>3</FRC_4>
   <FRC_5>3</FRC_5>
   <FRC_6>3</FRC_6>
   <FRC_7>3</FRC_7>
</FRC_Variance>
```

This would allow less tolerance for deviation on more important roads and more tolerance on less important roads.