### PR TITLE
feat: Introduced support for polygon location type in protobuf format

### DIFF
--- a/proto/src/main/java/openlr/proto/decoder/LocationTypeDecoderRegistry.java
+++ b/proto/src/main/java/openlr/proto/decoder/LocationTypeDecoderRegistry.java
@@ -40,18 +40,14 @@ public class LocationTypeDecoderRegistry {
             case POLYGON:
                 return polygonDecoder;
             case POI_WITH_ACCESS_POINT:
-                break;
             case CIRCLE:
-                break;
             case CLOSED_LINE:
-                break;
             case RECTANGLE:
-                break;
             case GRID:
-                break;
             case UNKNOWN:
                 return null;
+            default:
+                throw new IllegalStateException();
         }
-        return null;
     }
 }

--- a/proto/src/main/java/openlr/proto/decoder/LocationTypeDecoderRegistry.java
+++ b/proto/src/main/java/openlr/proto/decoder/LocationTypeDecoderRegistry.java
@@ -3,6 +3,11 @@ package openlr.proto.decoder;
 import openlr.LocationType;
 
 public class LocationTypeDecoderRegistry {
+    private final LineDecoder lineDecoder;
+    private final GeoCoordinatesDecoder geoCoordinatesDecoder;
+    private final PointAlongLineDecoder pointAlongLineDecoder;
+    private final PolygonDecoder polygonDecoder;
+
     public static LocationTypeDecoderRegistry create() {
         LocationReferencePointDecoder locationReferencePointDecoder = new LocationReferencePointDecoder();
         LineDecoder lineDecoder = new LineDecoder(locationReferencePointDecoder);
@@ -16,11 +21,6 @@ public class LocationTypeDecoderRegistry {
                 pointAlongLineDecoder,
                 polygonDecoder);
     }
-
-    private final LineDecoder lineDecoder;
-    private final GeoCoordinatesDecoder geoCoordinatesDecoder;
-    private final PointAlongLineDecoder pointAlongLineDecoder;
-    private final PolygonDecoder polygonDecoder;
 
     LocationTypeDecoderRegistry(LineDecoder lineDecoder, GeoCoordinatesDecoder geoCoordinatesDecoder, PointAlongLineDecoder pointAlongLineDecoder, PolygonDecoder polygonDecoder) {
         this.lineDecoder = lineDecoder;

--- a/proto/src/main/java/openlr/proto/decoder/LocationTypeDecoderRegistry.java
+++ b/proto/src/main/java/openlr/proto/decoder/LocationTypeDecoderRegistry.java
@@ -8,21 +8,25 @@ public class LocationTypeDecoderRegistry {
         LineDecoder lineDecoder = new LineDecoder(locationReferencePointDecoder);
         GeoCoordinatesDecoder geoCoordinatesDecoder = new GeoCoordinatesDecoder();
         PointAlongLineDecoder pointAlongLineDecoder = new PointAlongLineDecoder(locationReferencePointDecoder);
+        PolygonDecoder polygonDecoder = new PolygonDecoder();
 
         return new LocationTypeDecoderRegistry(
                 lineDecoder,
                 geoCoordinatesDecoder,
-                pointAlongLineDecoder);
+                pointAlongLineDecoder,
+                polygonDecoder);
     }
 
     private final LineDecoder lineDecoder;
     private final GeoCoordinatesDecoder geoCoordinatesDecoder;
     private final PointAlongLineDecoder pointAlongLineDecoder;
+    private final PolygonDecoder polygonDecoder;
 
-    LocationTypeDecoderRegistry(LineDecoder lineDecoder, GeoCoordinatesDecoder geoCoordinatesDecoder, PointAlongLineDecoder pointAlongLineDecoder) {
+    LocationTypeDecoderRegistry(LineDecoder lineDecoder, GeoCoordinatesDecoder geoCoordinatesDecoder, PointAlongLineDecoder pointAlongLineDecoder, PolygonDecoder polygonDecoder) {
         this.lineDecoder = lineDecoder;
         this.geoCoordinatesDecoder = geoCoordinatesDecoder;
         this.pointAlongLineDecoder = pointAlongLineDecoder;
+        this.polygonDecoder = polygonDecoder;
     }
 
     public LocationReferenceDecoder getDecoder(LocationType locationType) {
@@ -33,11 +37,11 @@ public class LocationTypeDecoderRegistry {
                 return geoCoordinatesDecoder;
             case POINT_ALONG_LINE:
                 return pointAlongLineDecoder;
+            case POLYGON:
+                return polygonDecoder;
             case POI_WITH_ACCESS_POINT:
                 break;
             case CIRCLE:
-                break;
-            case POLYGON:
                 break;
             case CLOSED_LINE:
                 break;

--- a/proto/src/main/java/openlr/proto/decoder/PolygonDecoder.java
+++ b/proto/src/main/java/openlr/proto/decoder/PolygonDecoder.java
@@ -1,0 +1,38 @@
+package openlr.proto.decoder;
+
+import openlr.map.GeoCoordinates;
+import openlr.proto.OpenLRProtoException;
+import openlr.proto.OpenLRProtoStatusCode;
+import openlr.proto.impl.GeoCoordinatesProtoImpl;
+import openlr.proto.schema.Coordinates;
+import openlr.proto.schema.LocationReferenceData;
+import openlr.proto.schema.PolygonLocationReference;
+import openlr.rawLocRef.RawLocationReference;
+import openlr.rawLocRef.RawPolygonLocRef;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PolygonDecoder implements LocationReferenceDecoder {
+    @Override
+    public RawLocationReference decode(String id, LocationReferenceData data) throws OpenLRProtoException {
+        if (!data.hasPolygonLocationReference()) {
+            throw new OpenLRProtoException(OpenLRProtoStatusCode.MISSING_LOCATION_REFERENCE);
+        }
+
+        PolygonLocationReference polygonLocationReference = data.getPolygonLocationReference();
+
+        if (polygonLocationReference.getCoordinatesCount() == 0) {
+            throw new OpenLRProtoException(OpenLRProtoStatusCode.INVALID_LOCATION_REFERENCE);
+        }
+
+        List<GeoCoordinates> cornerPoints = new ArrayList<>();
+
+        for (Coordinates coordinates : polygonLocationReference.getCoordinatesList()) {
+            GeoCoordinatesProtoImpl cornerPoint = new GeoCoordinatesProtoImpl(coordinates.getLongitude(), coordinates.getLatitude());
+            cornerPoints.add(cornerPoint);
+        }
+
+        return new RawPolygonLocRef(id, cornerPoints);
+    }
+}

--- a/proto/src/main/java/openlr/proto/encoder/LocationTypeEncoderRegistry.java
+++ b/proto/src/main/java/openlr/proto/encoder/LocationTypeEncoderRegistry.java
@@ -3,6 +3,11 @@ package openlr.proto.encoder;
 import openlr.LocationType;
 
 public class LocationTypeEncoderRegistry {
+    private final LineEncoder lineEncoder;
+    private final GeoCoordinatesEncoder geoCoordinatesEncoder;
+    private final PointAlongLineEncoder pointAlongLineEncoder;
+    private final PolygonEncoder polygonEncoder;
+
     public static LocationTypeEncoderRegistry create() {
         LocationReferencePointEncoder locationReferencePointEncoder = new LocationReferencePointEncoder();
         LineEncoder lineEncoder = new LineEncoder(locationReferencePointEncoder);
@@ -12,11 +17,6 @@ public class LocationTypeEncoderRegistry {
 
         return new LocationTypeEncoderRegistry(lineEncoder, geoCoordinatesEncoder, pointAlongLineEncoder, polygonEncoder);
     }
-
-    private final LineEncoder lineEncoder;
-    private final GeoCoordinatesEncoder geoCoordinatesEncoder;
-    private final PointAlongLineEncoder pointAlongLineEncoder;
-    private final PolygonEncoder polygonEncoder;
 
     LocationTypeEncoderRegistry(LineEncoder lineEncoder, GeoCoordinatesEncoder geoCoordinatesEncoder, PointAlongLineEncoder pointAlongLineEncoder, PolygonEncoder polygonEncoder) {
         this.lineEncoder = lineEncoder;

--- a/proto/src/main/java/openlr/proto/encoder/LocationTypeEncoderRegistry.java
+++ b/proto/src/main/java/openlr/proto/encoder/LocationTypeEncoderRegistry.java
@@ -8,18 +8,21 @@ public class LocationTypeEncoderRegistry {
         LineEncoder lineEncoder = new LineEncoder(locationReferencePointEncoder);
         GeoCoordinatesEncoder geoCoordinatesEncoder = new GeoCoordinatesEncoder();
         PointAlongLineEncoder pointAlongLineEncoder = new PointAlongLineEncoder(locationReferencePointEncoder);
+        PolygonEncoder polygonEncoder = new PolygonEncoder();
 
-        return new LocationTypeEncoderRegistry(lineEncoder, geoCoordinatesEncoder, pointAlongLineEncoder);
+        return new LocationTypeEncoderRegistry(lineEncoder, geoCoordinatesEncoder, pointAlongLineEncoder, polygonEncoder);
     }
 
     private final LineEncoder lineEncoder;
     private final GeoCoordinatesEncoder geoCoordinatesEncoder;
     private final PointAlongLineEncoder pointAlongLineEncoder;
+    private final PolygonEncoder polygonEncoder;
 
-    LocationTypeEncoderRegistry(LineEncoder lineEncoder, GeoCoordinatesEncoder geoCoordinatesEncoder, PointAlongLineEncoder pointAlongLineEncoder) {
+    LocationTypeEncoderRegistry(LineEncoder lineEncoder, GeoCoordinatesEncoder geoCoordinatesEncoder, PointAlongLineEncoder pointAlongLineEncoder, PolygonEncoder polygonEncoder) {
         this.lineEncoder = lineEncoder;
         this.geoCoordinatesEncoder = geoCoordinatesEncoder;
         this.pointAlongLineEncoder = pointAlongLineEncoder;
+        this.polygonEncoder = polygonEncoder;
     }
 
     public LocationReferenceEncoder getEncoder(LocationType locationType) {
@@ -30,11 +33,11 @@ public class LocationTypeEncoderRegistry {
                 return geoCoordinatesEncoder;
             case POINT_ALONG_LINE:
                 return pointAlongLineEncoder;
+            case POLYGON:
+                return polygonEncoder;
             case POI_WITH_ACCESS_POINT:
                 break;
             case CIRCLE:
-                break;
-            case POLYGON:
                 break;
             case CLOSED_LINE:
                 break;

--- a/proto/src/main/java/openlr/proto/encoder/LocationTypeEncoderRegistry.java
+++ b/proto/src/main/java/openlr/proto/encoder/LocationTypeEncoderRegistry.java
@@ -36,18 +36,14 @@ public class LocationTypeEncoderRegistry {
             case POLYGON:
                 return polygonEncoder;
             case POI_WITH_ACCESS_POINT:
-                break;
             case CIRCLE:
-                break;
             case CLOSED_LINE:
-                break;
             case RECTANGLE:
-                break;
             case GRID:
-                break;
             case UNKNOWN:
                 return null;
+            default:
+                throw new IllegalStateException();
         }
-        return null;
     }
 }

--- a/proto/src/main/java/openlr/proto/encoder/PolygonEncoder.java
+++ b/proto/src/main/java/openlr/proto/encoder/PolygonEncoder.java
@@ -1,0 +1,44 @@
+package openlr.proto.encoder;
+
+import openlr.LocationReference;
+import openlr.LocationType;
+import openlr.map.GeoCoordinates;
+import openlr.proto.OpenLRProtoException;
+import openlr.proto.OpenLRProtoStatusCode;
+import openlr.proto.impl.LocationReferenceProtoImpl;
+import openlr.proto.schema.Coordinates;
+import openlr.proto.schema.LocationReferenceData;
+import openlr.proto.schema.PolygonLocationReference;
+import openlr.rawLocRef.RawLocationReference;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PolygonEncoder implements LocationReferenceEncoder {
+    @Override
+    public LocationReference encode(RawLocationReference rawLocationReference) throws OpenLRProtoException {
+        if (rawLocationReference.getLocationType() != LocationType.POLYGON) {
+            throw new OpenLRProtoException(OpenLRProtoStatusCode.INVALID_LOCATION_REFERENCE);
+        }
+
+        List<Coordinates> coordinates = new ArrayList<>();
+
+        for (GeoCoordinates cornerPoint : rawLocationReference.getCornerPoints()) {
+            Coordinates c = Coordinates.newBuilder()
+                    .setLongitude(cornerPoint.getLongitudeDeg())
+                    .setLatitude(cornerPoint.getLatitudeDeg())
+                    .build();
+            coordinates.add(c);
+        }
+
+        PolygonLocationReference polygonLocationReference = PolygonLocationReference.newBuilder()
+                .addAllCoordinates(coordinates)
+                .build();
+
+        LocationReferenceData locationReferenceData = LocationReferenceData.newBuilder()
+                .setPolygonLocationReference(polygonLocationReference)
+                .build();
+
+        return new LocationReferenceProtoImpl(rawLocationReference.getID(), LocationType.POLYGON, locationReferenceData);
+    }
+}

--- a/proto/src/main/resources/openlr.proto
+++ b/proto/src/main/resources/openlr.proto
@@ -79,10 +79,15 @@ message PointAlongLineLocationReference {
     Orientation orientation = 5;
 }
 
+message PolygonLocationReference {
+    repeated Coordinates coordinates = 1;
+}
+
 message LocationReferenceData {
     oneof locationReference {
         LineLocationReference lineLocationReference = 1;
         GeoCoordinatesLocationReference geoCoordinatesLocationReference = 2;
         PointAlongLineLocationReference pointAlongLineLocationReference = 3;
+        PolygonLocationReference polygonLocationReference = 4;
     }
 }

--- a/proto/src/test/java/openlr/proto/OpenLRProtoDecoderTest.java
+++ b/proto/src/test/java/openlr/proto/OpenLRProtoDecoderTest.java
@@ -161,6 +161,43 @@ public class OpenLRProtoDecoderTest {
     }
 
     @Test
+    public void testPolygonLocationReference() throws PhysicalFormatException {
+        Coordinates first = Coordinates.newBuilder()
+                .setLongitude(-122.915)
+                .setLatitude(39.045)
+                .build();
+
+        Coordinates second = Coordinates.newBuilder()
+                .setLongitude(-122.914)
+                .setLatitude(39.046)
+                .build();
+
+        Coordinates third = Coordinates.newBuilder()
+                .setLongitude(-122.913)
+                .setLatitude(39.047)
+                .build();
+
+        PolygonLocationReference polygonLocationReference = PolygonLocationReference.newBuilder()
+                .addCoordinates(first)
+                .addCoordinates(second)
+                .addCoordinates(third)
+                .build();
+
+        LocationReferenceData locationReferenceData = LocationReferenceData.newBuilder()
+                .setPolygonLocationReference(polygonLocationReference)
+                .build();
+
+        LocationReference locationReference = new LocationReferenceProtoImpl("1", LocationType.POLYGON, locationReferenceData);
+
+        RawLocationReference rawLocationReference = decoder.decodeData(locationReference);
+
+        assertNotNull(rawLocationReference);
+        assertEquals(rawLocationReference.getID(), "1");
+        assertEquals(rawLocationReference.getLocationType(), LocationType.POLYGON);
+        assertTrue(rawLocationReference.isValid());
+    }
+
+    @Test
     public void testUnsupportedLocationType() {
         LocationReferenceData locationReferenceData = LocationReferenceData.newBuilder()
                 .build();

--- a/proto/src/test/java/openlr/proto/OpenLRProtoEncoderTest.java
+++ b/proto/src/test/java/openlr/proto/OpenLRProtoEncoderTest.java
@@ -17,6 +17,7 @@ import openlr.rawLocRef.RawCircleLocRef;
 import openlr.rawLocRef.RawGeoCoordLocRef;
 import openlr.rawLocRef.RawLineLocRef;
 import openlr.rawLocRef.RawPointAlongLocRef;
+import openlr.rawLocRef.RawPolygonLocRef;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
@@ -129,6 +130,24 @@ public class OpenLRProtoEncoderTest {
         assertEquals(locationReference.getDataIdentifier(), "proto");
         assertEquals(locationReference.getDataClass(), LocationReferenceData.class);
         assertNotNull(locationReference.getLocationReferenceData());
+    }
+
+    @Test
+    public void testPolygonLocationReference() {
+        List<GeoCoordinates> geoCoordinates = new ArrayList<>();
+        geoCoordinates.add(new GeoCoordinatesProtoImpl(-122.915, 39.045));
+        geoCoordinates.add(new GeoCoordinatesProtoImpl(-122.914, 39.046));
+        geoCoordinates.add(new GeoCoordinatesProtoImpl(-122.913, 39.047));
+
+        RawPolygonLocRef rawLocationReference = new RawPolygonLocRef("1", geoCoordinates);
+
+        LocationReference locationReference = openLREncoder.encodeData(rawLocationReference);
+
+        assertNotNull(locationReference);
+        assertEquals(locationReference.getID(), "1");
+        assertEquals(locationReference.getLocationType(), LocationType.POLYGON);
+        assertEquals(locationReference.getDataIdentifier(), "proto");
+        assertEquals(locationReference.getDataClass(), LocationReferenceData.class);
     }
 
     @Test

--- a/proto/src/test/java/openlr/proto/decoder/PolygonDecoderTest.java
+++ b/proto/src/test/java/openlr/proto/decoder/PolygonDecoderTest.java
@@ -1,0 +1,104 @@
+package openlr.proto.decoder;
+
+import openlr.LocationType;
+import openlr.PhysicalFormatException;
+import openlr.map.GeoCoordinates;
+import openlr.proto.OpenLRProtoStatusCode;
+import openlr.proto.schema.Coordinates;
+import openlr.proto.schema.LocationReferenceData;
+import openlr.proto.schema.PolygonLocationReference;
+import openlr.rawLocRef.RawLocationReference;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+
+public class PolygonDecoderTest {
+    PolygonDecoder polygonDecoder = new PolygonDecoder();
+
+    @Test
+    public void testValidLocationReference() throws PhysicalFormatException {
+        Coordinates first = Coordinates.newBuilder()
+                .setLongitude(-122.915)
+                .setLatitude(39.045)
+                .build();
+
+        Coordinates second = Coordinates.newBuilder()
+                .setLongitude(-122.914)
+                .setLatitude(39.046)
+                .build();
+
+        Coordinates third = Coordinates.newBuilder()
+                .setLongitude(-122.913)
+                .setLatitude(39.047)
+                .build();
+
+        PolygonLocationReference polygonLocationReference = PolygonLocationReference.newBuilder()
+                .addCoordinates(first)
+                .addCoordinates(second)
+                .addCoordinates(third)
+                .build();
+
+        LocationReferenceData locationReferenceData = LocationReferenceData.newBuilder()
+                .setPolygonLocationReference(polygonLocationReference)
+                .build();
+
+        RawLocationReference rawLocationReference = polygonDecoder.decode("1", locationReferenceData);
+
+        assertNotNull(rawLocationReference);
+        assertEquals("1", rawLocationReference.getID());
+        assertEquals(LocationType.POLYGON, rawLocationReference.getLocationType());
+
+        List<GeoCoordinates> cornerPoints = rawLocationReference.getCornerPoints();
+        assertNotNull(cornerPoints);
+        assertEquals(cornerPoints.size(), 3);
+
+        GeoCoordinates firstCornerPoint = cornerPoints.get(0);
+        assertNotNull(firstCornerPoint);
+        assertEquals(firstCornerPoint.getLongitudeDeg(), -122.915);
+        assertEquals(firstCornerPoint.getLatitudeDeg(), 39.045);
+
+        GeoCoordinates secondCornerPoint = cornerPoints.get(1);
+        assertNotNull(secondCornerPoint);
+        assertEquals(secondCornerPoint.getLongitudeDeg(), -122.914);
+        assertEquals(secondCornerPoint.getLatitudeDeg(), 39.046);
+
+        GeoCoordinates thirdCornerPoint = cornerPoints.get(2);
+        assertNotNull(thirdCornerPoint);
+        assertEquals(thirdCornerPoint.getLongitudeDeg(), -122.913);
+        assertEquals(thirdCornerPoint.getLatitudeDeg(), 39.047);
+    }
+
+    @Test
+    public void testMissingLocationReference() {
+        LocationReferenceData locationReferenceData = LocationReferenceData.newBuilder()
+                .build();
+
+        try {
+            polygonDecoder.decode("1", locationReferenceData);
+            fail();
+        } catch (PhysicalFormatException e) {
+            assertEquals(e.getErrorCode(), OpenLRProtoStatusCode.MISSING_LOCATION_REFERENCE);
+        }
+    }
+
+    @Test
+    public void testInvalidLocationReference() {
+        PolygonLocationReference polygonLocationReference = PolygonLocationReference.newBuilder()
+                .build();
+
+        LocationReferenceData locationReferenceData = LocationReferenceData.newBuilder()
+                .setPolygonLocationReference(polygonLocationReference)
+                .build();
+
+        try {
+            polygonDecoder.decode("1", locationReferenceData);
+            fail();
+        } catch (PhysicalFormatException e) {
+            assertEquals(e.getErrorCode(), OpenLRProtoStatusCode.INVALID_LOCATION_REFERENCE);
+        }
+    }
+}

--- a/proto/src/test/java/openlr/proto/decoder/PolygonDecoderTest.java
+++ b/proto/src/test/java/openlr/proto/decoder/PolygonDecoderTest.java
@@ -17,7 +17,7 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
 
 public class PolygonDecoderTest {
-    PolygonDecoder polygonDecoder = new PolygonDecoder();
+    private PolygonDecoder polygonDecoder = new PolygonDecoder();
 
     @Test
     public void testValidLocationReference() throws PhysicalFormatException {

--- a/proto/src/test/java/openlr/proto/encoder/PolygonEncoderTest.java
+++ b/proto/src/test/java/openlr/proto/encoder/PolygonEncoderTest.java
@@ -1,0 +1,70 @@
+package openlr.proto.encoder;
+
+import openlr.LocationReference;
+import openlr.LocationType;
+import openlr.map.GeoCoordinates;
+import openlr.proto.OpenLRProtoException;
+import openlr.proto.impl.GeoCoordinatesProtoImpl;
+import openlr.proto.schema.Coordinates;
+import openlr.proto.schema.LocationReferenceData;
+import openlr.proto.schema.PolygonLocationReference;
+import openlr.rawLocRef.RawPolygonLocRef;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class PolygonEncoderTest {
+    PolygonEncoder polygonEncoder = new PolygonEncoder();
+
+    @Test
+    public void testEncodePolygon() throws OpenLRProtoException {
+        List<GeoCoordinates> geoCoordinates = new ArrayList<>();
+        geoCoordinates.add(new GeoCoordinatesProtoImpl(-122.915, 39.045));
+        geoCoordinates.add(new GeoCoordinatesProtoImpl(-122.914, 39.046));
+        geoCoordinates.add(new GeoCoordinatesProtoImpl(-122.913, 39.047));
+
+        RawPolygonLocRef rawLocationReference = new RawPolygonLocRef("1", geoCoordinates);
+
+        LocationReference locationReference = polygonEncoder.encode(rawLocationReference);
+
+        assertNotNull(locationReference);
+        assertEquals(locationReference.getID(), "1");
+        assertEquals(locationReference.getLocationType(), LocationType.POLYGON);
+        assertEquals(locationReference.getDataIdentifier(), "proto");
+        assertEquals(locationReference.getDataClass(), LocationReferenceData.class);
+
+        Object locationReferenceData = locationReference.getLocationReferenceData();
+
+        assertTrue(locationReferenceData instanceof LocationReferenceData);
+
+        LocationReferenceData data = (LocationReferenceData) locationReferenceData;
+
+        assertTrue(data.hasPolygonLocationReference());
+
+        PolygonLocationReference polygonLocationReference = data.getPolygonLocationReference();
+
+        List<Coordinates> coordinatesList = polygonLocationReference.getCoordinatesList();
+
+        assertEquals(coordinatesList.size(), 3);
+
+        Coordinates first = coordinatesList.get(0);
+        assertNotNull(first);
+        assertEquals(first.getLongitude(), -122.915);
+        assertEquals(first.getLatitude(), 39.045);
+
+        Coordinates second = coordinatesList.get(1);
+        assertNotNull(second);
+        assertEquals(second.getLongitude(), -122.914);
+        assertEquals(second.getLatitude(), 39.046);
+
+        Coordinates third = coordinatesList.get(2);
+        assertNotNull(third);
+        assertEquals(third.getLongitude(), -122.913);
+        assertEquals(third.getLatitude(), 39.047);
+    }
+}

--- a/proto/src/test/java/openlr/proto/encoder/PolygonEncoderTest.java
+++ b/proto/src/test/java/openlr/proto/encoder/PolygonEncoderTest.java
@@ -19,7 +19,7 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 public class PolygonEncoderTest {
-    PolygonEncoder polygonEncoder = new PolygonEncoder();
+    private PolygonEncoder polygonEncoder = new PolygonEncoder();
 
     @Test
     public void testEncodePolygon() throws OpenLRProtoException {


### PR DESCRIPTION
This change introduces a new `PolygonLocationReference` message to the protobuf format and support for encoding to and decoding from this.  The `PolygonLocationReference` message uses absolute coordinates rather than relative coordinates so there is no loss of precision when transferring locations of this type (like with the older binary format).