### PR TITLE
The performance and memory consumption for decoder are improved with topK algorithm implementation.

### DIFF
--- a/decoder/src/main/java/openlr/decoder/data/CandidateLinePair.java
+++ b/decoder/src/main/java/openlr/decoder/data/CandidateLinePair.java
@@ -54,6 +54,7 @@ package openlr.decoder.data;
 
 import java.io.Serializable;
 import java.util.Comparator;
+import java.util.Objects;
 
 
 /**
@@ -127,33 +128,19 @@ public class CandidateLinePair {
      */
     @Override
     public final String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("startIdx: ").append(startIndex);
-        sb.append(" destIdx: ").append(destIndex);
-        sb.append(" score: ").append(score);
-        return sb.toString();
+        return String.format("startIdx: [%d], destIdx: [%d], score: [%d]", startIndex, destIndex, score);
     }
 
-    /**
-     * The Class CandidatePairComparator provides a comparator for candidate pairs. The comparator
-     * sorts according to better (greater) score values.
-     */
-    public static class CandidateLinePairComparator implements Comparator<CandidateLinePair>, Serializable {
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CandidateLinePair that = (CandidateLinePair) o;
+        return startIndex == that.startIndex && destIndex == that.destIndex && score == that.score;
+    }
 
-        /**
-         * Serialization ID
-         */
-        private static final long serialVersionUID = -5038985615293780820L;
-
-        /** {@inheritDoc} */
-        @Override
-        public final int compare(final CandidateLinePair o1, final CandidateLinePair o2) {
-            if (o1.score < o2.score) {
-                return 1;
-            } else if (o1.score > o2.score) {
-                return -1;
-            }
-            return 0;
-        }
+    @Override
+    public int hashCode() {
+        return Objects.hash(startIndex, destIndex, score);
     }
 }

--- a/decoder/src/test/java/openlr/decoder/data/CandidateLineTest.java
+++ b/decoder/src/test/java/openlr/decoder/data/CandidateLineTest.java
@@ -52,7 +52,6 @@ package openlr.decoder.data;
 
 import openlr.decoder.TestData;
 import openlr.decoder.data.CandidateLine.CandidateLineComparator;
-import openlr.decoder.data.CandidateLinePair.CandidateLinePairComparator;
 import openlr.map.Line;
 import org.testng.annotations.Test;
 
@@ -130,52 +129,8 @@ public class CandidateLineTest {
     @Test
     public final void testToString() {
         TestData td = TestData.getInstance();
-        CandidateLine line = new CandidateLine(td.getMapDatabase().getLine(1),
-                RATIO_1000, -1);
+        CandidateLine line = new CandidateLine(td.getMapDatabase().getLine(1), RATIO_1000, -1);
         assertNotNull(line.toString());
-    }
-
-
-    /**
-     * Test the comparison of line objects.
-     */
-    @Test
-    public final void testComparisonPair() {
-
-        CandidateLinePair scoreOneA = new CandidateLinePair(0, 1, 1);
-        CandidateLinePair scoreOneB = new CandidateLinePair(0, 1, 1);
-        CandidateLinePair scoreMax = new CandidateLinePair(0, 2,
-                Integer.MAX_VALUE);
-        CandidateLinePair scoreMin = new CandidateLinePair(1, 2,
-                Integer.MIN_VALUE);
-        CandidateLinePair scoreZero = new CandidateLinePair(2, 1, 0);
-
-        assertEquals(scoreOneA.getStartIndex(), scoreMax.getStartIndex());
-        assertEquals(scoreMin.getDestIndex(), scoreMax.getDestIndex());
-        assertEquals(scoreOneA.getScore(), scoreOneB.getScore());
-
-        CandidateLinePairComparator comp = new CandidateLinePairComparator();
-        assertTrue(comp.compare(scoreOneA, scoreOneA) == 0);
-        assertTrue(comp.compare(scoreOneA, scoreOneB) == 0);
-        assertTrue(comp.compare(scoreMax, scoreOneA) < 0);
-        assertTrue(comp.compare(scoreOneA, scoreMax) > 0);
-        assertTrue(comp.compare(scoreMin, scoreMax) > 0);
-        assertTrue(comp.compare(scoreMax, scoreMin) < 0);
-        assertTrue(comp.compare(scoreMax, scoreMax) == 0);
-        assertTrue(comp.compare(scoreMax, scoreZero) < 0);
-        assertTrue(comp.compare(scoreZero, scoreMax) > 0);
-
-        CandidateLinePair[] expectedSorting = new CandidateLinePair[]{
-                scoreMax, scoreOneA, scoreZero, scoreMin};
-
-        List<CandidateLinePair> pairs = Arrays.asList(scoreMax, scoreOneA,
-                scoreMin, scoreZero);
-        Collections.sort(pairs, new CandidateLinePairComparator());
-
-        for (int i = 0; i < expectedSorting.length; i++) {
-            assertSame(pairs.get(i), expectedSorting[i],
-                    "Unexpected entry at index " + i);
-        }
     }
 
     /**

--- a/decoder/src/test/java/openlr/decoder/worker/DecoderUtilsTest.java
+++ b/decoder/src/test/java/openlr/decoder/worker/DecoderUtilsTest.java
@@ -14,7 +14,12 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
 public class DecoderUtilsTest {
 
@@ -98,11 +103,17 @@ public class DecoderUtilsTest {
         clrs.putCandidateLines(lrp3, candidates3);
 
         try {
-            List<CandidateLinePair> order = DecoderUtils
-                    .resolveCandidatesOrder(lrp1, lrp2, clrs, null,
+            List<CandidateLinePair> order = Arrays.asList(
+                    new CandidateLinePair(0, 0, 1393308L),
+                    new CandidateLinePair(0, 1, 1375353L),
+                    new CandidateLinePair(1, 0, 1292040L),
+                    new CandidateLinePair(1, 1, 1275390L)
+            );
+
+            assertEquals(DecoderUtils.resolveCandidatesOrder(lrp1, lrp2, clrs, null,
                             new OpenLRDecoderProperties(null),
-                            LocationType.LINE_LOCATION);
-            //System.out.println(order);
+                            LocationType.LINE_LOCATION),
+                    order);
         } catch (OpenLRProcessingException e) {
             e.printStackTrace();
             Assert.fail("Unexpected exception");


### PR DESCRIPTION
Changes performed:
* Removed useless comparator for CandidateLinePair, cleanup unit test
* Changed CndidateLinePair score to long, prevents int overflow
* Improved DecodeUtils.resolveCandidatesOrder from O( N*log(N) ) time
  and O(N) space to O( N*log(K) ) time and O(K) space, where N could be
  hundreds of thousands and K is digits, so K << N.
* Improved DecodeUtils unit test