### PR TITLE
Bearing calculation reverse last point direction

### DIFF
--- a/decoder/src/main/java/openlr/decoder/rating/OpenLRRatingImpl.java
+++ b/decoder/src/main/java/openlr/decoder/rating/OpenLRRatingImpl.java
@@ -94,11 +94,12 @@ public class OpenLRRatingImpl implements OpenLRRating {
                                final Line line, final int projectionAlongLine)
             throws OpenLRProcessingException {
         BearingDirection dir = null;
-        if (p.isLastLRP()) {
-            dir = BearingDirection.AGAINST_DIRECTION;
-        } else {
+        // I believe we don't need to do this check
+        //if (p.isLastLRP()) {
+        //    dir = BearingDirection.AGAINST_DIRECTION;
+        //} else {
             dir = BearingDirection.IN_DIRECTION;
-        }
+        //}
 
         int nodeRating = calculateDistanceRating(properties, distance);
 


### PR DESCRIPTION
In the rating implementation, when do the last point bearing calculation, do we need to reverse the direction? Recently, we found the matching rate has some trouble, and after debug into, found the issue is caused by this direction change for last point.  If we remove this line, the MAX_BEAR_DIFF can set as normal, otherwise, we have to set as 180.  So I believe we should remove this line, but not sure what is the reason we put it in there