### PR TITLE
Add MinScore to Bearing_Rating decoding parameters

### DIFF
--- a/decoder/src/main/java/openlr/decoder/properties/OpenLRDecoderProperties.java
+++ b/decoder/src/main/java/openlr/decoder/properties/OpenLRDecoderProperties.java
@@ -74,6 +74,9 @@ public class OpenLRDecoderProperties {
     /** The max bearing diff. */
     private final int maxBearingDiff;
 
+    /** The minimum bearing score.  Candidates with bearing scores less than this value will be disregarded. */
+    private final int minBearingScore;
+
     /** The maximum score bearing rating can contribute to the overall rating. */
     private final int maxBearingScore;
 
@@ -138,6 +141,7 @@ public class OpenLRDecoderProperties {
         dnpVariance = OpenLRPropertyAccess.getIntegerPropertyValue(config,
                 OpenLRDecoderProperty.DNP_VARIANCE);
         maxBearingDiff = OpenLRPropertyAccess.getIntegerPropertyValueFromMap(config, OpenLRDecoderProperty.BEAR_RATING, "MaxBearingDiff");
+        minBearingScore = OpenLRPropertyAccess.getIntegerPropertyValueFromMap(config, OpenLRDecoderProperty.BEAR_RATING, "MinScore");
         maxBearingScore = OpenLRPropertyAccess.getIntegerPropertyValueFromMap(config, OpenLRDecoderProperty.BEAR_RATING, "MaxScore");
 
         frcRating = new EnumMap<RatingCategory, Integer>(RatingCategory.class);
@@ -270,6 +274,15 @@ public class OpenLRDecoderProperties {
      */
     public final int getMaxBearingDiff() {
         return maxBearingDiff;
+    }
+
+    /**
+     * Gets the min bearing score.
+     *
+     * @return the maxBearingDiff
+     */
+    public final int getMinBearingScore() {
+        return minBearingScore;
     }
 
     /**

--- a/decoder/src/main/java/openlr/decoder/properties/OpenLRDecoderProperty.java
+++ b/decoder/src/main/java/openlr/decoder/properties/OpenLRDecoderProperty.java
@@ -135,6 +135,11 @@ public enum OpenLRDecoderProperty implements OpenLRProperty {
                     /**
                      * Maximum score bearing rating can contribute to the overall candidate line rating
                      */
+                    put("MinScore", 0);
+
+                    /**
+                     * Maximum score bearing rating can contribute to the overall candidate line rating
+                     */
                     put("MaxScore", 100);
 
                     /**

--- a/decoder/src/main/java/openlr/decoder/rating/OpenLRRatingImpl.java
+++ b/decoder/src/main/java/openlr/decoder/rating/OpenLRRatingImpl.java
@@ -108,10 +108,17 @@ public class OpenLRRatingImpl implements OpenLRRating {
 
         int bearingRating = calculateBearingRating(properties, p.getBearing(),
                 dir, line, projectionAlongLine);
+        
+        // verify bearing rating is >= minimum threshold
         if (bearingRating < properties.getMinBearingScore()) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("bearing of a candidate line is out of range ["
-                        + line.getID() + "]");
+                LOG.debug("candidate ["
+                        + line.getID()  + "] ignored: bearing rating (" 
+                        + bearingRating
+                        + ") < Bearing_Rating.MinScore ("
+                        + properties.getMinBearingScore()
+                        + ")"
+                        );
             }
             return -1;
         }

--- a/decoder/src/main/java/openlr/decoder/rating/OpenLRRatingImpl.java
+++ b/decoder/src/main/java/openlr/decoder/rating/OpenLRRatingImpl.java
@@ -108,7 +108,7 @@ public class OpenLRRatingImpl implements OpenLRRating {
 
         int bearingRating = calculateBearingRating(properties, p.getBearing(),
                 dir, line, projectionAlongLine);
-        if (bearingRating < 0) {
+        if (bearingRating < properties.getMinBearingScore()) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("bearing of a candidate line is out of range ["
                         + line.getID() + "]");

--- a/decoder/src/main/resources/OpenLR-Decoder-Properties.xml
+++ b/decoder/src/main/resources/OpenLR-Decoder-Properties.xml
@@ -52,6 +52,7 @@
         <Poor>25</Poor>
     </FOW_Rating>
     <Bearing_Rating>
+        <MinScore>0</MinScore>
         <MaxScore>100</MaxScore>
         <MaxBearingDiff>45</MaxBearingDiff>
     </Bearing_Rating>
@@ -61,6 +62,5 @@
     <SameLineDegradation>0.10</SameLineDegradation>
     <ConnectedRouteIncrease>0.10</ConnectedRouteIncrease>
     <DNPVariance>118</DNPVariance>
-    <maxBearingDiff>90</maxBearingDiff>
     <Calc_Affected_Lines>false</Calc_Affected_Lines>
 </ml:OpenLRDecoderProperties>

--- a/decoder/src/test/java/openlr/decoder/data/OpenLRRatingImplTest.java
+++ b/decoder/src/test/java/openlr/decoder/data/OpenLRRatingImplTest.java
@@ -27,6 +27,7 @@
  */
 package openlr.decoder.data;
 
+import java.util.HashMap;
 import openlr.LocationReferencePoint;
 import openlr.OpenLRProcessingException;
 import openlr.decoder.TestData;
@@ -51,17 +52,18 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
 /**
- * The Class TestTTLRRating.
+ * The Class OpenLRRatingImplTest.
+ * 
+ * Tests the effect on candidate rating of the Bearing_Rating.MinScore attribute
  */
 public class OpenLRRatingImplTest {
-
 
     /** The value used for parameter projectionAlongLine of the test on line 26 */
     public static final int PROJECTION_LINE_26 = 22;
 
     /** The bearing value of the test LRP #1 */
     private static final double BEARING_LRP_1 = 162.9;
-    /** The bearing value of the test LRP #1 */
+    /** The bearing value of the test LRP #2 */
     private static final double BEARING_LRP_2 = 256.67;
 
     /** The expected result of rating test #1. */
@@ -70,24 +72,37 @@ public class OpenLRRatingImplTest {
     private static final int EXPECTED_RESULT_RATING_2 = 494;
     /** The expected result of rating test #3. */
     private static final int EXPECTED_RESULT_RATING_3 = 755;
+    /** The expected result of rating test #3. */
+    private static final int EXPECTED_RESULT_MIN_SCORE_REJECT = -1;
 
     /** The non-junction node factor to apply for tests */
     private static final float NON_JUNCTION_NODE_FACTOR = 0.8f;
 
-    /** The expected result of rating test with junction node with no non-junction node factor. */
+    /**
+     * The expected result of rating test with junction node with no non-junction
+     * node factor.
+     */
     private static final int EXPECTED_RESULT_RATING_JUNCTION_NODE_NO_NON_JUNCTION_NODE_FACTOR = 1002;
-    /** The expected result of rating test with junction node with a non-junction node factor. */
+    /**
+     * The expected result of rating test with junction node with a non-junction
+     * node factor.
+     */
     private static final int EXPECTED_RESULT_RATING_JUNCTION_NODE_NON_JUNCTION_NODE_FACTOR = 1002;
-    /** The expected result of rating test with non-junction node with no non-junction node factor. */
+    /**
+     * The expected result of rating test with non-junction node with no
+     * non-junction node factor.
+     */
     private static final int EXPECTED_RESULT_RATING_NON_JUNCTION_NODE_NO_NON_JUNCTION_NODE_FACTOR = 852;
-    /** The expected result of rating test with non-junction node with a non-junction node factor. */
+    /**
+     * The expected result of rating test with non-junction node with a non-junction
+     * node factor.
+     */
     private static final int EXPECTED_RESULT_RATING_NON_JUNCTION_NODE_NON_JUNCTION_NODE_FACTOR = 798;
 
     /** The distance value of rating test #1. */
     private static final int DISTANCE_RATING_1 = 14;
     /** The distance value of rating test #2. */
     private static final int DISTANCE_RATING_2 = 3;
-
 
     /** The ID of line 4 of the test map. */
     private static final int TEST_LINE_4 = 4;
@@ -270,6 +285,34 @@ public class OpenLRRatingImplTest {
     }
 
     /**
+     * Test effect of default Bearing_Rating.MinScore on rating score when bearing score
+     * is >= Bearing_Rating.MinScore.  The candidate rating should be unchanged
+     */
+    @Test
+    public final void testRatingBearingMinScoreAccept() throws OpenLRProcessingException {
+        OpenLRDecoderProperties properties = getPropertiesWithBearingMinScore();
+
+        // Should succeed.  Expected bearing score: 73, MinScore = 65
+        int rating1 = RATING_FUNCTION.getRating(properties,
+                DISTANCE_RATING_1, point1, line10, 0);
+        assertEquals(rating1, EXPECTED_RESULT_RATING_1);
+    }
+
+    /**
+     * Test effect of default Bearing_Rating.MinScore on rating score when bearing score
+     * is less than Bearing_Rating.MinScore.  The rating should be -1, causing the 
+     * candidate to be rejected.
+     */
+    @Test
+    public final void testRatingBearingMinScoreReject() throws OpenLRProcessingException {
+        OpenLRDecoderProperties properties = getPropertiesWithBearingMinScore();
+
+        // Should be rejected.  Expected bearing score: 62, MinScore = 65
+        int rating = RATING_FUNCTION.getRating(properties,
+                DISTANCE_RATING_2, point2, line26, PROJECTION_LINE_26);
+        assertEquals(EXPECTED_RESULT_MIN_SCORE_REJECT, rating);
+    }
+    /**
      * Instantiates the properties.
      *
      * @return the properties
@@ -291,4 +334,26 @@ public class OpenLRRatingImplTest {
         return properties;
     }
 
+    /**
+     * Instantiates the properties.
+     *
+     * @return the properties
+     */
+    private OpenLRDecoderProperties getPropertiesWithBearingMinScore() {
+        OpenLRDecoderProperties local_properties = null;
+
+        File validProperties = new File(
+                "src/test/resources/DecoderPropertiesBearingMinScore.xml");
+        try {
+            local_properties = new OpenLRDecoderProperties(OpenLRPropertiesReader
+                    .loadPropertiesFromStream(new FileInputStream(validProperties), true));
+        } catch (OpenLRProcessingException e) {
+            fail("failed to load valid properties file", e);
+        } catch (FileNotFoundException e) {
+            fail("cannot find properties file", e);
+        }
+
+        return local_properties;
+
+    }
 }

--- a/decoder/src/test/java/openlr/decoder/data/OpenLRRatingImplTest.java
+++ b/decoder/src/test/java/openlr/decoder/data/OpenLRRatingImplTest.java
@@ -295,6 +295,7 @@ public class OpenLRRatingImplTest {
         // Should succeed.  Expected bearing score: 73, MinScore = 65
         int rating1 = RATING_FUNCTION.getRating(properties,
                 DISTANCE_RATING_1, point1, line10, 0);
+
         assertEquals(rating1, EXPECTED_RESULT_RATING_1);
     }
 
@@ -310,6 +311,7 @@ public class OpenLRRatingImplTest {
         // Should be rejected.  Expected bearing score: 62, MinScore = 65
         int rating = RATING_FUNCTION.getRating(properties,
                 DISTANCE_RATING_2, point2, line26, PROJECTION_LINE_26);
+
         assertEquals(EXPECTED_RESULT_MIN_SCORE_REJECT, rating);
     }
     /**
@@ -335,7 +337,8 @@ public class OpenLRRatingImplTest {
     }
 
     /**
-     * Instantiates the properties.
+     * Instantiates properties from the xml file that specified a non-default
+     * MinScore bearing parameter.
      *
      * @return the properties
      */

--- a/decoder/src/test/java/openlr/decoder/properties/DecoderPropertiesTest.java
+++ b/decoder/src/test/java/openlr/decoder/properties/DecoderPropertiesTest.java
@@ -157,6 +157,9 @@ public class DecoderPropertiesTest {
 
             assertEquals(OpenLRPropertyAccess.getIntegerPropertyValueFromMap(
                     prop, OpenLRDecoderProperty.BEAR_RATING,
+                    "MinScore"), 0);
+            assertEquals(OpenLRPropertyAccess.getIntegerPropertyValueFromMap(
+                    prop, OpenLRDecoderProperty.BEAR_RATING,
                     "MaxScore"), 100);
             assertEquals(OpenLRPropertyAccess.getIntegerPropertyValueFromMap(
                     prop, OpenLRDecoderProperty.BEAR_RATING,

--- a/decoder/src/test/java/openlr/decoder/worker/LineDecoderTest.java
+++ b/decoder/src/test/java/openlr/decoder/worker/LineDecoderTest.java
@@ -157,14 +157,14 @@ public class LineDecoderTest {
             13.538750, 52.615403, 2750, FunctionalRoadClass.FRC_0,
             FormOfWay.MOTORWAY, FunctionalRoadClass.FRC_0, 95.6, false, 0);
     /**
-     * The first LRP of the location, but with a bearing that produces a bearing rating of 66, which is
-     * just acceptable given a Bear_Rating.MinScore = 65 in DecoderpropertiesBearingMinScore.xml
+     * The first LRP of the LONG location, but with an altered bearing that produces a bearing rating of 66, 
+     * which is just acceptable given a Bear_Rating.MinScore = 65 in DecoderpropertiesBearingMinScore.xml
      */
     private static final LocationReferencePoint LRP_START_LONG_BAD_BEARING_ACCEPTABLE = new TestLocationReferencePointImpl(
             13.538750, 52.615403, 2750, FunctionalRoadClass.FRC_0,
             FormOfWay.MOTORWAY, FunctionalRoadClass.FRC_0, 81.0, false, 0);
     /**
-     * The first LRP of the location, but with a bearing that produces a bearing rating less than the 
+     * The first LRP of the LONG location, but with a bearing that produces a bearing rating less than the 
      * Bear_Rating.MinScore = 65 in DecoderpropertiesBearingMinScore.xml and therefore finds no candidates.
      */
     private static final LocationReferencePoint LRP_START_LONG_BAD_BEARING_REJECT = new TestLocationReferencePointImpl(
@@ -331,7 +331,8 @@ public class LineDecoderTest {
 
 
     /**
-     * Tests a long location wit offsets that goes over multiple lines
+     * Tests that candidates are discarded from consideration if the bearing score is
+     * less than or equal to the <Bearing_Rating>.<MinScore> attribute.
      */
     @Test
     public final void testFindCandidates() {

--- a/decoder/src/test/resources/DecoderPropertiesBearingMinScore.xml
+++ b/decoder/src/test/resources/DecoderPropertiesBearingMinScore.xml
@@ -50,6 +50,7 @@
         <Poor>25</Poor>
     </FOW_Rating>
     <Bearing_Rating>
+        <MinScore>65</MinScore>
         <MaxScore>100</MaxScore>
         <MaxBearingDiff>45</MaxBearingDiff>
     </Bearing_Rating>


### PR DESCRIPTION
Add <MinScore> parameter to the <Bearing_Rating> node in the decoding parameters and associated logic such that if the bearing score of a candidate line is strictly less than this value, it will be excluded from consideration when searching for candidate lines for a particular LRP.  As the smallest value returned by OpenLRRatingImpl.calculateBearingRating() is >= 0, the default value is 0 so that the new logic  will not effect existing users.  Also added test cases.