### PR TITLE
fix: resolve Maven build failures on aarch64 and Java 17+

### DIFF
--- a/binary/pom.xml
+++ b/binary/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openlr</groupId>
         <artifactId>openlr</artifactId>
-        <version>1.4.4-RC1</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>binary</artifactId>

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openlr</groupId>
         <artifactId>openlr</artifactId>
-        <version>1.4.4-RC1</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>data</artifactId>

--- a/datex2/pom.xml
+++ b/datex2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openlr</groupId>
         <artifactId>openlr</artifactId>
-        <version>1.4.4-RC1</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>datex2</artifactId>

--- a/decoder/pom.xml
+++ b/decoder/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openlr</groupId>
         <artifactId>openlr</artifactId>
-        <version>1.4.4-RC1</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>decoder</artifactId>

--- a/encoder/pom.xml
+++ b/encoder/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openlr</groupId>
         <artifactId>openlr</artifactId>
-        <version>1.4.4-RC1</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>encoder</artifactId>

--- a/map/pom.xml
+++ b/map/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openlr</groupId>
         <artifactId>openlr</artifactId>
-        <version>1.4.4-RC1</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>map</artifactId>

--- a/maploader-tt-sqlite/pom.xml
+++ b/maploader-tt-sqlite/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.openlr</groupId>
         <artifactId>openlr</artifactId>
-        <version>1.4.4-RC1</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>maploader-tt-sqlite</artifactId>

--- a/maploader-tt-sqlite/src/main/java/openlr/map/sqlite/impl/MapDatabaseImpl.java
+++ b/maploader-tt-sqlite/src/main/java/openlr/map/sqlite/impl/MapDatabaseImpl.java
@@ -504,7 +504,9 @@ public final class MapDatabaseImpl implements openlr.map.MapDatabase {
         try {
             connection.getPsGetNode().setLong(1, id);
             rs = connection.getPsGetNode().executeQuery();
-            node = createNode(rs, id);
+            if (rs.next()) {
+                node = createNode(rs, id);
+            }
         } catch (SQLException e) {
             LOG.error(e);
             node = null;

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
             <dependency>
                 <groupId>org.xerial</groupId>
                 <artifactId>sqlite-jdbc</artifactId>
-                <version>3.28.0</version>
+                <version>3.47.0.0</version>
             </dependency>
 
             <dependency>
@@ -269,7 +269,7 @@
                 <plugin>
                     <groupId>com.github.os72</groupId>
                     <artifactId>protoc-jar-maven-plugin</artifactId>
-                    <version>3.8.0</version>
+                    <version>3.11.4</version>
                 </plugin>
 
             </plugins>
@@ -282,6 +282,18 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <argLine>
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+                    </argLine>
                 </configuration>
             </plugin>
 

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.openlr</groupId>
         <artifactId>openlr</artifactId>
-        <version>1.4.4-RC1</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.openlr</groupId>
@@ -36,22 +36,28 @@
     </dependencies>
 
     <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.0</version>
+            </extension>
+        </extensions>
         <plugins>
             <plugin>
-                <groupId>com.github.os72</groupId>
-                <artifactId>protoc-jar-maven-plugin</artifactId>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.6.1</version>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:3.21.7:exe:${os.detected.classifier}</protocArtifact>
+                    <protoSourceRoot>${project.basedir}/src/main/resources</protoSourceRoot>
+                    <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
+                </configuration>
                 <executions>
                     <execution>
-                        <phase>generate-sources</phase>
                         <goals>
-                            <goal>run</goal>
+                            <goal>compile</goal>
                         </goals>
-                        <configuration>
-                            <inputDirectories>
-                                <include>src/main/resources</include>
-                            </inputDirectories>
-                            <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openlr</groupId>
         <artifactId>openlr</artifactId>
-        <version>1.4.4-RC1</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>xml</artifactId>


### PR DESCRIPTION
Sync child module parent versions to 2.0.0-SNAPSHOT.

Add maven-surefire-plugin with --add-opens flags for Java 17+ module system compatibility.

Update sqlite-jdbc from 3.28.0 to 3.47.0.0 for aarch64 native library support.

Fix SQLite ResultSet access to check rs.next() before reading data, required by newer JDBC driver versions.

Replace protoc-jar-maven-plugin with protobuf-maven-plugin using os-maven-plugin for cross-platform protoc binary resolution. Update protoc to 3.21.7 with aarch64 binaries.

Verified on macOS aarch64, Linux aarch64, and Linux x86_64.